### PR TITLE
Make Checker.check return a type annotated AST

### DIFF
--- a/frontend/src/Language/Granule/Checker/Checker.hs
+++ b/frontend/src/Language/Granule/Checker/Checker.hs
@@ -42,7 +42,7 @@ import Language.Granule.Utils
 --import Debug.Trace
 
 -- Checking (top-level)
-check :: (?globals :: Globals) => AST () () -> IO (Maybe ())
+check :: (?globals :: Globals) => AST () () -> IO (Maybe (AST () Type))
 check (AST dataDecls defs) = evalChecker initState $ do
     rs1 <- mapM (runMaybeT . checkTyCon) dataDecls
     rs2 <- mapM (runMaybeT . checkDataCons) dataDecls
@@ -51,7 +51,7 @@ check (AST dataDecls defs) = evalChecker initState $ do
 
     return $
       if all isJust (rs1 <> rs2 <> rs3 <> (map (fmap (const ())) rs4))
-        then Just () -- TODO: add Ed's elaborated AST back in here ResultType with rs4
+        then Just (AST dataDecls (catMaybes rs4))
         else Nothing
   where
     defCtxt = map (\(Def _ name _ tys) -> (name, tys)) defs

--- a/frontend/src/Language/Granule/Syntax/Def.hs
+++ b/frontend/src/Language/Granule/Syntax/Def.hs
@@ -26,6 +26,7 @@ import Language.Granule.Syntax.Pattern
 data AST v a = AST [DataDecl] [Def v a]
 
 deriving instance (Show v, Show a) => Show (AST v a)
+deriving instance (Eq v, Eq a) => Eq (AST v a)
 deriving instance Functor (AST v)
 
 -- | Function definitions
@@ -40,14 +41,16 @@ data Equation v a =
 deriving instance Functor (Def v)
 deriving instance Functor (Equation v)
 deriving instance (Show v, Show a) => Show (Def v a)
+deriving instance (Eq v, Eq a) => Eq (Def v a)
 deriving instance (Show v, Show a) => Show (Equation v a)
+deriving instance (Eq v, Eq a) => Eq (Equation v a)
 
 instance FirstParameter (Def v a) Span
 instance FirstParameter (Equation v a) Span
 
 -- | Data type declarations
 data DataDecl = DataDecl Span Id [(Id,Kind)] (Maybe Kind) [DataConstr]
-  deriving (Generic, Show)
+  deriving (Generic, Show, Eq)
 
 instance FirstParameter DataDecl Span
 

--- a/frontend/src/Language/Granule/Syntax/Def.hs
+++ b/frontend/src/Language/Granule/Syntax/Def.hs
@@ -25,7 +25,7 @@ import Language.Granule.Syntax.Pattern
 -- | where `v` is the type of values and `a` annotations
 data AST v a = AST [DataDecl] [Def v a]
 
-deriving instance (Show (Value v a), Show a) => Show (AST v a)
+deriving instance (Show v, Show a) => Show (AST v a)
 deriving instance Functor (AST v)
 
 -- | Function definitions
@@ -39,8 +39,8 @@ data Equation v a =
 
 deriving instance Functor (Def v)
 deriving instance Functor (Equation v)
-deriving instance (Show (Value v a), Show a) => Show (Def v a)
-deriving instance (Show (Value v a), Show a) => Show (Equation v a)
+deriving instance (Show v, Show a) => Show (Def v a)
+deriving instance (Show v, Show a) => Show (Equation v a)
 
 instance FirstParameter (Def v a) Span
 instance FirstParameter (Equation v a) Span

--- a/frontend/src/Language/Granule/Syntax/Expr.hs
+++ b/frontend/src/Language/Granule/Syntax/Expr.hs
@@ -41,7 +41,7 @@ data Value v a = Abs a (Pattern a) (Maybe Type) (Expr v a)
    deriving (Generic)
 
 instance FirstParameter (Value v a) a
-deriving instance Show v => Show (Value v ())
+deriving instance (Show v, Show a) => Show (Value v a)
 deriving instance Functor (Value v)
 
 -- | Expressions (computations) in Granule (with `v` extended values

--- a/frontend/src/Language/Granule/Syntax/Expr.hs
+++ b/frontend/src/Language/Granule/Syntax/Expr.hs
@@ -42,6 +42,7 @@ data Value v a = Abs a (Pattern a) (Maybe Type) (Expr v a)
 
 instance FirstParameter (Value v a) a
 deriving instance (Show v, Show a) => Show (Value v a)
+deriving instance (Eq v, Eq a) => Eq (Value v a)
 deriving instance Functor (Value v)
 
 -- | Expressions (computations) in Granule (with `v` extended values
@@ -60,7 +61,9 @@ data Expr v a =
   | Case Span a (Expr v a) [(Pattern a, Expr v a)]
   deriving (Generic)
 
-deriving instance (Show (Value v a), Show a) => Show (Expr v a)
+deriving instance (Show v, Show a) => Show (Expr v a)
+deriving instance (Eq v, Eq a) => Eq (Expr v a)
+
 deriving instance Functor (Expr v)
 
 instance FirstParameter (Expr v a) Span

--- a/frontend/tests/hspec/Language/Granule/Checker/CheckerSpec.hs
+++ b/frontend/tests/hspec/Language/Granule/Checker/CheckerSpec.hs
@@ -5,7 +5,7 @@ module Language.Granule.Checker.CheckerSpec where
 
 import Control.Exception (SomeException, try)
 import Control.Monad (forM_, liftM2)
-import Data.Maybe (fromJust)
+import Data.Maybe (fromJust, isJust)
 
 import System.FilePath.Find
 import Test.Hspec
@@ -63,7 +63,7 @@ spec = do
             result <- try (check ast) :: IO (Either SomeException _)
             case result of
                 Left ex -> expectationFailure (show ex) -- an exception was thrown
-                Right checked -> checked `shouldBe` Just ()
+                Right checked -> checked `shouldSatisfy` isJust
     -- Negative tests: things which should fail to check
     srcFiles <- runIO illTypedFiles
     forM_ srcFiles $ \file ->


### PR DESCRIPTION
The work for this was done in the `typeElaboration` branch but wasn't propagated up into the check method as done here.