### PR TITLE
Remove redundant boxes in LeftPad examples

### DIFF
--- a/examples/LeftPadShort.gr
+++ b/examples/LeftPadShort.gr
@@ -5,9 +5,9 @@ import Nat
 
 leftPad : forall {t : Type, m : Nat, n : Nat}
         . Vec n t -> t [m - n] -> N m -> Vec (n ∨ m) t
-leftPad str [c] n =
+leftPad str c n =
   let (m, str) = length' str
-  in append (replicate (monus n m) [c]) str
+  in append (replicate (monus n m) c) str
 
 -- The type says that given an input vector of length `n` and a target
 -- length `m` then we must consume the padding element of type `t`

--- a/examples/LeftPadTutorial.gr
+++ b/examples/LeftPadTutorial.gr
@@ -95,9 +95,9 @@ sub (S m') (S n') = sub m' n'
 
 leftPad : forall {t : Type, m : Nat, n : Nat}
         . {m >= n} => Vec n t -> t [m - n] -> N m -> Vec m t
-leftPad str [c] n =
+leftPad str c n =
   let (m, str) = length' str
-  in append (replicate (sub n m) [c]) str
+  in append (replicate (sub n m) c) str
 
 -- The type says that given a target length an input vector of length `n`
 -- and a target length `m` that is greater than or equal to `m`, then we

--- a/examples/LeftPadTutorial.gr
+++ b/examples/LeftPadTutorial.gr
@@ -49,7 +49,7 @@ length (Cons [_] xs) = S (length xs)
 
 -- The type `t [0]` represents values of type `t` wrapped in a
 -- "graded modality" whose "grade" (index) states that the value
--- is used 0 times. This non-linear behaviour is then access by
+-- is used 0 times. This non-linear behaviour is then accessed by
 -- the "unboxing" pattern match in the second equation of `length`.
 
 -- Alternatively, we can reconstruct the vector and return it


### PR DESCRIPTION
- fixes a typo and removes some (I believe) redundant unboxing and boxing