### PR TITLE
Add (ungraded) uniqueness semiring

### DIFF
--- a/examples/borrowing.gr
+++ b/examples/borrowing.gr
@@ -1,0 +1,13 @@
+-- examples copied from nonlinear.gr to check that One behaves like 
+-- Lin and Omega behaves like NonLin
+
+copy : ∀ {a : Type} . a [Omega] -> (a, a [Omega])
+copy [x] = (x, [x])
+
+drop : forall {a : Type} . a [Omega] -> a
+drop [x] = x
+
+extract : forall {a : Type} . a [One] -> a
+extract [x] = x
+
+-- todo: add some examples experimenting with Beta

--- a/examples/uniqueness.gr
+++ b/examples/uniqueness.gr
@@ -1,0 +1,27 @@
+
+redeem : forall {p, q : Type} . (p [NonUnique] -> q) -> p -> q
+redeem f x = f (nonuniqueReturn x)
+
+-- Can't implement this as we can't go from p (linear) to p []
+redeem' : forall {p, q : Type} . (p [] -> q) -> p -> q
+redeem' = ?
+
+weaken : forall {p, q, r : Type} . (q -> r) -> p [NonUnique] -> q -> r
+weaken f [a] b = f b
+
+weaken' : forall {p, q, r : Type} . (q -> r) -> p [] -> q -> r
+weaken' f [a] b = f b
+
+contract : forall {p, q : Type} . (p [NonUnique] -> p [NonUnique] -> q) -> p [NonUnique] -> q
+contract f [a] = f [a] [a]
+
+contract' : forall {p, q : Type} . (p [] -> p [] -> q) -> p [] -> q
+contract' f [a] = f [a] [a]
+
+-- Can't implement this as we can't go from p [NonUnique] to p
+derelict : forall {p, q, r : Type} . (p -> q) -> p [NonUnique] -> q
+-- derelict f [a] = f a
+derelict = ?
+
+derelict' : forall {p, q, r : Type} . (p -> q) -> p [] -> q
+derelict' f [a] = f a

--- a/examples/uniqueness.gr
+++ b/examples/uniqueness.gr
@@ -1,25 +1,25 @@
 
-redeem : forall {p, q : Type} . (p [NonUnique] -> q) -> p -> q
-redeem f x = f (nonuniqueReturn x)
+redeem : forall {p, q : Type} . (p [] -> q [Unique]) -> p [Unique] -> q [Unique]
+redeem f x = f (uniqueReturn x)
 
 -- Can't implement this as we can't go from p (linear) to p []
 redeem' : forall {p, q : Type} . (p [] -> q) -> p -> q
 redeem' = ?
 
-weaken : forall {p, q, r : Type} . (q -> r) -> p [NonUnique] -> q -> r
+weaken : forall {p, q, r : Type} . (q [Unique] -> r [Unique]) -> p [] -> q [Unique] -> r [Unique]
 weaken f [a] b = f b
 
 weaken' : forall {p, q, r : Type} . (q -> r) -> p [] -> q -> r
 weaken' f [a] b = f b
 
-contract : forall {p, q : Type} . (p [NonUnique] -> p [NonUnique] -> q) -> p [NonUnique] -> q
+contract : forall {p, q : Type} . (p [] -> p [] -> q [Unique]) -> p [] -> q [Unique]
 contract f [a] = f [a] [a]
 
 contract' : forall {p, q : Type} . (p [] -> p [] -> q) -> p [] -> q
 contract' f [a] = f [a] [a]
 
--- Can't implement this as we can't go from p [NonUnique] to p
-derelict : forall {p, q, r : Type} . (p -> q) -> p [NonUnique] -> q
+-- Can't implement this as we can't go from p [] to p [Unique]
+derelict : forall {p, q, r : Type} . (p [Unique] -> q [Unique]) -> p [] -> q [Unique]
 -- derelict f [a] = f a
 derelict = ?
 

--- a/examples/uniqueness.gr
+++ b/examples/uniqueness.gr
@@ -1,27 +1,39 @@
+import Cake
 
+-- Fine, since we can go from unique to unrestricted (forget a uniqueness guarantee)
 redeem : forall {p, q : Type} . (p [] -> q [Unique]) -> p [Unique] -> q [Unique]
 redeem f x = f (uniqueReturn x)
 
--- Can't implement this as we can't go from p (linear) to p []
+-- Can't implement this as we can't go from unrestricted to unique (generate a uniqueness guarantee)
+derelict : forall {p, q, r : Type} . (p [Unique] -> q [Unique]) -> p [] -> q [Unique]
+derelict = ?
+
+-- Fine, since we can go from unrestricted to linear (impose a linearity restriction)
+derelict' : forall {p, q, r : Type} . (p -> q) -> p [] -> q
+derelict' f [a] = f a
+
+-- Can't implement this as we can't go from linear to unrestricted (bypass a linearity restriction)
 redeem' : forall {p, q : Type} . (p [] -> q) -> p -> q
 redeem' = ?
 
+-- Weakening is allowed for unrestricted values...
 weaken : forall {p, q, r : Type} . (q [Unique] -> r [Unique]) -> p [] -> q [Unique] -> r [Unique]
 weaken f [a] b = f b
 
 weaken' : forall {p, q, r : Type} . (q -> r) -> p [] -> q -> r
 weaken' f [a] b = f b
 
+-- ...and so is contraction!
 contract : forall {p, q : Type} . (p [] -> p [] -> q [Unique]) -> p [] -> q [Unique]
 contract f [a] = f [a] [a]
 
 contract' : forall {p, q : Type} . (p [] -> p [] -> q) -> p [] -> q
 contract' f [a] = f [a] [a]
 
--- Can't implement this as we can't go from p [] to p [Unique]
-derelict : forall {p, q, r : Type} . (p [Unique] -> q [Unique]) -> p [] -> q [Unique]
--- derelict f [a] = f a
-derelict = ?
+-- If we start with a unique cake, we can't have it and eat it too...
+badDesire : Cake [Unique] -> (Happy, Cake [Unique])
+badDesire uniqueCake = ?
 
-derelict' : forall {p, q, r : Type} . (p -> q) -> p [] -> q
-derelict' f [a] = f a
+-- ...unless we are willing to accept that our cake won't be unique any more :)
+goodDesire : Cake [Unique] -> (Happy, Cake)
+goodDesire uniqueCake = let [cake] = uniqueReturn lotsOfCake in (eat cake, have cake)

--- a/examples/uniqueness.gr
+++ b/examples/uniqueness.gr
@@ -16,19 +16,13 @@ derelict' f [a] = f a
 redeem' : forall {p, q : Type} . (p [] -> q) -> p -> q
 redeem' = ?
 
--- Weakening is allowed for unrestricted values...
-weaken : forall {p, q, r : Type} . (q [Unique] -> r [Unique]) -> p [] -> q [Unique] -> r [Unique]
-weaken f [a] b = f b
+-- Contraction is allowed for unrestricted values...
+dup : forall {p : Type} . p [Unique] -> (p, p)
+dup a = let [u] = uniqueReturn a in (u, u)
 
-weaken' : forall {p, q, r : Type} . (q -> r) -> p [] -> q -> r
-weaken' f [a] b = f b
-
--- ...and so is contraction!
-contract : forall {p, q : Type} . (p [] -> p [] -> q [Unique]) -> p [] -> q [Unique]
-contract f [a] = f [a] [a]
-
-contract' : forall {p, q : Type} . (p [] -> p [] -> q) -> p [] -> q
-contract' f [a] = f [a] [a]
+-- ...and so is weakening!
+fst : forall {p, q : Type} . (p, q [Unique]) -> p
+fst (a, b) = let [u] = uniqueReturn b in a
 
 -- If we start with a unique cake, we can't have it and eat it too...
 badDesire : Cake [Unique] -> (Happy, Cake [Unique])
@@ -36,4 +30,4 @@ badDesire uniqueCake = ?
 
 -- ...unless we are willing to accept that our cake won't be unique any more :)
 goodDesire : Cake [Unique] -> (Happy, Cake)
-goodDesire uniqueCake = let [cake] = uniqueReturn lotsOfCake in (eat cake, have cake)
+goodDesire uniqueCake = let [cake] = uniqueReturn uniqueCake in (eat cake, have cake)

--- a/frontend/src/Language/Granule/Checker/Constraints.hs
+++ b/frontend/src/Language/Granule/Checker/Constraints.hs
@@ -441,7 +441,6 @@ compileCoeffect (TyGrade k' 1) k vars = do
         "Q"         -> return (SFloat (fromRational 1), sTrue)
         "OOZ"       -> return (SOOZ sTrue, sTrue)
         "LNL"       -> return (SLNL sFalse, sTrue)
-        "Uniqueness" -> return (SUnique, sTrue)
         "Borrowing" -> return (SBorrow (literal oneRepresentation), sTrue)
         _           -> solverError $ "I don't know how to compile a 1 for " <> pretty k
 

--- a/frontend/src/Language/Granule/Checker/Constraints.hs
+++ b/frontend/src/Language/Granule/Checker/Constraints.hs
@@ -154,7 +154,7 @@ freshSolverVarScoped quant name (TyCon (internalName -> "LNL")) q k =
 
 freshSolverVarScoped (quant :: Quantifier -> String -> (SBV Integer -> Symbolic SBool) -> Symbolic SBool) 
                       name (TyCon (internalName -> "Uniqueness")) q k =
-    quant q name (\solverVar -> k (sTrue, SNonUnique))
+    quant q name (\solverVar -> k (sTrue, SUnique))
 
 freshSolverVarScoped quant name (TyCon conName) q k =
     -- Integer based
@@ -316,7 +316,7 @@ compileCoeffect (TyCon name) (TyCon (internalName -> "Sec")) _ = do
     c    -> error $ "Cannot compile " <> show c <> " as a Sec semiring"
 
 compileCoeffect (TyCon name) (TyCon (internalName -> "Uniqueness")) _ = do
-  return (SNonUnique, sTrue)
+  return (SUnique, sTrue)
 
 -- TODO: I think the following two cases are deprecatd: (DAO 12/08/2019)
 compileCoeffect (TyApp (TyCon (internalName -> "Level")) (TyInt n)) (isProduct -> Just (TyCon (internalName -> "Level"), t2)) vars = do
@@ -409,7 +409,6 @@ compileCoeffect (TyGrade k' 0) k vars = do
         "OOZ"       -> return (SOOZ sFalse, sTrue)
         "LNL"       -> return (SLNL sTrue, sTrue)
         "Borrowing" -> return (SBorrow (literal omegaRepresentation), sTrue)
-        "Uniqueness" -> return (SNonUnique, sTrue)
         _           -> solverError $ "I don't know how to compile a 0 for " <> pretty k
     otherK | otherK == extendedNat ->
       return (SExtNat 0, sTrue)
@@ -442,6 +441,7 @@ compileCoeffect (TyGrade k' 1) k vars = do
         "Q"         -> return (SFloat (fromRational 1), sTrue)
         "OOZ"       -> return (SOOZ sTrue, sTrue)
         "LNL"       -> return (SLNL sFalse, sTrue)
+        "Uniqueness" -> return (SUnique, sTrue)
         "Borrowing" -> return (SBorrow (literal oneRepresentation), sTrue)
         _           -> solverError $ "I don't know how to compile a 1 for " <> pretty k
 
@@ -543,7 +543,7 @@ approximatedByOrEqualConstraint (SLNL a) (SLNL b) =
 
 approximatedByOrEqualConstraint (SBorrow a) (SBorrow b) = return $ a .<= b
 
-approximatedByOrEqualConstraint SNonUnique SNonUnique = return $ sTrue
+approximatedByOrEqualConstraint SUnique SUnique = return $ sTrue
 
 approximatedByOrEqualConstraint s t | isSProduct s && isSProduct t =
   either solverError id (applyToProducts approximatedByOrEqualConstraint (.&&) (const sTrue) s t)

--- a/frontend/src/Language/Granule/Checker/Constraints/SymbolicGrades.hs
+++ b/frontend/src/Language/Granule/Checker/Constraints/SymbolicGrades.hs
@@ -373,7 +373,6 @@ symGradeTimes (SInterval lb1 ub1) (SInterval lb2 ub2) =
         b `f` ub1ub2
 
 symGradeTimes SPoint SPoint = return SPoint
-symGradeTimes SUnique SUnique = return $ SUnique
 symGradeTimes s t | isSProduct s || isSProduct t =
   either solverError id (applyToProducts symGradeTimes SProduct id s t)
 

--- a/frontend/src/Language/Granule/Checker/Constraints/SymbolicGrades.hs
+++ b/frontend/src/Language/Granule/Checker/Constraints/SymbolicGrades.hs
@@ -39,6 +39,8 @@ data SGrade =
      | SOOZ SBool
      -- LNL
      | SLNL SBool -- True = NonLin, False = Lin
+     -- Borrowing
+     | SBorrow SInteger
      -- Uniqueness
      | SNonUnique
 
@@ -62,6 +64,12 @@ unusedRepresentation  = 0
 hiRepresentation, loRepresentation :: SBool
 hiRepresentation = sTrue
 loRepresentation = sFalse
+
+-- Representation for `Borrowing`
+oneRepresentation, betaRepresentation, omegaRepresentation :: Integer
+oneRepresentation   = 1
+betaRepresentation  = 2
+omegaRepresentation = 3
 
 -- Representation of semiring terms as a `SynTree`
 data SynTree =
@@ -139,6 +147,7 @@ match (SUnknown _) (SUnknown _) = True
 match (SOOZ _) (SOOZ _) = True
 match (SSec _) (SSec _) = True
 match (SLNL _) (SLNL _) = True
+match (SBorrow _) (SBorrow _) = True
 match SNonUnique SNonUnique = True
 match _ _ = False
 
@@ -199,6 +208,7 @@ instance Mergeable SGrade where
   symbolicMerge s sb (SUnknown a) (SUnknown b) = SUnknown (SynMerge sb a b)
   symbolicMerge s sb (SSec a) (SSec b) = SSec (symbolicMerge s sb a b)
   symbolicMerge s sb (SLNL a) (SLNL b) = SLNL (symbolicMerge s sb a b)
+  symbolicMerge s sb (SBorrow a) (SBorrow b) = SBorrow (symbolicMerge s sb a b)
   symbolicMerge s sb SNonUnique SNonUnique = SNonUnique
 
   symbolicMerge _ _ s t = error $ cannotDo "symbolicMerge" s t
@@ -213,6 +223,7 @@ symGradeLess (SLevel n) (SLevel n') = return $ n .< n'
 symGradeLess (SSet n) (SSet n')     = solverError "Can't compare symbolic sets yet"
 symGradeLess (SExtNat n) (SExtNat n') = return $ n .< n'
 symGradeLess SPoint SPoint            = return sTrue
+symGradeLess (SBorrow n) (SBorrow n') = return $ n .< n'
 symGradeLess (SUnknown s) (SUnknown t) = sLtTree s t
 
 symGradeLess s t | isSProduct s || isSProduct t =
@@ -254,6 +265,7 @@ symGradeEq s t | isSProduct s || isSProduct t =
 symGradeEq (SUnknown t) (SUnknown t') = sEqTree t t'
 symGradeEq (SSec n) (SSec n') = return $ n .== n'
 symGradeEq (SLNL n) (SLNL m) = return $ n .== m
+symGradeEq (SBorrow n) (SBorrow m) = return $ n .== m
 symGradeEq SNonUnique SNonUnique = return $ sTrue
 symGradeEq s t = solverError $ cannotDo ".==" s t
 
@@ -328,6 +340,7 @@ symGradePlus (SUnknown um) (SUnknown un) =
 
 symGradePlus (SSec a) (SSec b) = symGradeMeet (SSec a) (SSec b)
 symGradePlus (SLNL a) (SLNL b) = return $ SLNL sTrue
+symGradePlus (SBorrow a) (SBorrow b) = return $ SBorrow (a `smax` b `smax` literal betaRepresentation)
 symGradePlus SNonUnique SNonUnique = return $ SNonUnique
 
 symGradePlus s t = solverError $ cannotDo "plus" s t
@@ -388,6 +401,7 @@ symGradeTimes (SUnknown um) (SUnknown un) =
 
 symGradeTimes (SSec a) (SSec b) = symGradeJoin (SSec a) (SSec b)
 symGradeTimes (SLNL a) (SLNL b) = return $ SLNL $ a .&& b
+symGradeTimes (SBorrow a) (SBorrow b) = return $ SBorrow $ a `smax` b
 
 symGradeTimes s t = solverError $ cannotDo "times" s t
 

--- a/frontend/src/Language/Granule/Checker/Primitives.hs
+++ b/frontend/src/Language/Granule/Checker/Primitives.hs
@@ -51,6 +51,11 @@ typeConstructors =
     -- LNL members
     , (mkId "Lin",        (tyCon "LNL", [], False))
     , (mkId "NonLin",     (tyCon "LNL", [], False))
+    -- Borrowing
+    , (mkId "Borrowing", (kcoeffect, [], False))
+    , (mkId "One",       (tyCon "Borrowing", [], False))
+    , (mkId "Beta",      (tyCon "Borrowing", [], False))
+    , (mkId "Omega",     (tyCon "Borrowing", [], False))
     -- Security levels
     , (mkId "Level",    (kcoeffect, [], False)) -- Security level
     , (mkId "Private",  (tyCon "Level", [], False))

--- a/frontend/src/Language/Granule/Checker/Primitives.hs
+++ b/frontend/src/Language/Granule/Checker/Primitives.hs
@@ -60,6 +60,9 @@ typeConstructors =
     , (mkId "Sec",  (kcoeffect, [], False))
     , (mkId "Hi",    (tyCon "Sec", [], False))
     , (mkId "Lo",    (tyCon "Sec", [], False))
+    -- Uniqueness
+    , (mkId "Uniqueness", (kcoeffect, [], False))
+    , (mkId "NonUnique", (tyCon "Uniqueness", [], False))
     -- Other coeffect constructors
     , (mkId "Infinity", ((tyCon "Ext") .@ (tyCon "Nat"), [], False))
     , (mkId "Interval", (kcoeffect .-> kcoeffect, [], False))
@@ -466,6 +469,19 @@ tick = BUILTIN
 --   . Ptr id -> Cap a id -> a
 -- freePtr = BUILTIN
 
+--------------------------------------------------------------------------------
+-- Uniqueness monadic operations
+--------------------------------------------------------------------------------
+
+nonuniqueReturn
+  : forall {a : Type}
+  . a -> a [NonUnique]
+nonuniqueReturn = BUILTIN
+
+nonuniqueBind
+  : forall {a b : Type}
+  . (a -> b [NonUnique]) -> a [NonUnique] -> b [NonUnique]
+nonuniqueBind = BUILTIN
 
 |]
 

--- a/frontend/src/Language/Granule/Checker/Primitives.hs
+++ b/frontend/src/Language/Granule/Checker/Primitives.hs
@@ -479,8 +479,8 @@ tick = BUILTIN
 --------------------------------------------------------------------------------
 
 uniqueReturn
-  : forall {a : Type, k : Coeffect, c : k}
-  . a [Unique] -> a [c]
+  : forall {a : Type}
+  . a [Unique] -> a []
 uniqueReturn = BUILTIN
 
 uniqueBind

--- a/frontend/src/Language/Granule/Checker/Primitives.hs
+++ b/frontend/src/Language/Granule/Checker/Primitives.hs
@@ -67,7 +67,7 @@ typeConstructors =
     , (mkId "Lo",    (tyCon "Sec", [], False))
     -- Uniqueness
     , (mkId "Uniqueness", (kcoeffect, [], False))
-    , (mkId "NonUnique", (tyCon "Uniqueness", [], False))
+    , (mkId "Unique", (tyCon "Uniqueness", [], False))
     -- Other coeffect constructors
     , (mkId "Infinity", ((tyCon "Ext") .@ (tyCon "Nat"), [], False))
     , (mkId "Interval", (kcoeffect .-> kcoeffect, [], False))
@@ -478,15 +478,15 @@ tick = BUILTIN
 -- Uniqueness monadic operations
 --------------------------------------------------------------------------------
 
-nonuniqueReturn
-  : forall {a : Type}
-  . a -> a [NonUnique]
-nonuniqueReturn = BUILTIN
+uniqueReturn
+  : forall {a : Type, k : Coeffect, c : k}
+  . a [Unique] -> a [c]
+uniqueReturn = BUILTIN
 
-nonuniqueBind
-  : forall {a b : Type}
-  . (a -> b [NonUnique]) -> a [NonUnique] -> b [NonUnique]
-nonuniqueBind = BUILTIN
+uniqueBind
+  : forall {a b : Type, k : Coeffect, c : k}
+  . (a [Unique] -> b [c]) -> a [c] -> b [c]
+uniqueBind = BUILTIN
 
 |]
 

--- a/frontend/src/Language/Granule/Syntax/Type.hs
+++ b/frontend/src/Language/Granule/Syntax/Type.hs
@@ -153,6 +153,9 @@ level = tyCon "Level"
 infinity :: Type
 infinity = tyCon "Infinity"
 
+uniqueness :: Type
+uniqueness = tyCon "Uniqueness"
+
 isInterval :: Type -> Maybe Type
 isInterval (TyApp (TyCon c) t) | internalName c == "Interval" = Just t
 isInterval _ = Nothing

--- a/interpreter/src/Language/Granule/Interpreter/Eval.hs
+++ b/interpreter/src/Language/Granule/Interpreter/Eval.hs
@@ -375,6 +375,8 @@ builtIns =
   -- , (mkId "newPtr", malloc)
   -- , (mkId "swapPtr", peek poke castPtr) -- hmm probably don't need to cast the Ptr
   -- , (mkId "freePtr", free)
+  , (mkId "nonuniqueReturn",   Ext () $ Primitive $ \v -> Promote () (Val nullSpan () False v))
+  , (mkId "nonuniqueBind",    Ext () $ Primitive $ \f -> Ext () $ Primitive $ \(Promote () (Val nullSpan () False v)) -> Promote () (App nullSpan () False (Val nullSpan () False f) (Val nullSpan () False v)))
   ]
   where
     forkLinear :: (?globals :: Globals) => Ctxt RValue -> RValue -> RValue

--- a/interpreter/src/Language/Granule/Interpreter/Eval.hs
+++ b/interpreter/src/Language/Granule/Interpreter/Eval.hs
@@ -375,8 +375,8 @@ builtIns =
   -- , (mkId "newPtr", malloc)
   -- , (mkId "swapPtr", peek poke castPtr) -- hmm probably don't need to cast the Ptr
   -- , (mkId "freePtr", free)
-  , (mkId "nonuniqueReturn",   Ext () $ Primitive $ \v -> Promote () (Val nullSpan () False v))
-  , (mkId "nonuniqueBind",    Ext () $ Primitive $ \f -> Ext () $ Primitive $ \(Promote () (Val nullSpan () False v)) -> Promote () (App nullSpan () False (Val nullSpan () False f) (Val nullSpan () False v)))
+  , (mkId "uniqueReturn",  Ext () $ Primitive $ \(Promote () (Val nullSpan () False v)) -> Promote () (Val nullSpan () False v))
+  , (mkId "uniqueBind",    Ext () $ Primitive $ \(Promote () (Val nullSpan () False f)) -> Ext () $ Primitive $ \(Promote () (Val nullSpan () False v)) -> Promote () (App nullSpan () False (Val nullSpan () False f) (Val nullSpan () False v)))
   ]
   where
     forkLinear :: (?globals :: Globals) => Ctxt RValue -> RValue -> RValue


### PR DESCRIPTION
This adds a Uniqueness semiring with a single grade, Unique, representing values that are unique in the sense that only one reference to such a value exists (like uniqueness types in Clean, for example).

A unique value can be transformed into an unrestricted value by using the uniqueReturn primitive - so uniqueReturn has the type a [Unique] -> a [] for all a - but then of course it is no longer possible to guarantee uniqueness. Therefore it is not possible to construct a unique value out of a value that is not itself unique.

Some examples of how this works and how it behaves alongside linearity can be seen in examples/uniqueness.gr.