### PR TITLE
Bump text-replace version to fix "stack build"

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -8,7 +8,7 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps:
 - ConfigFile-1.1.4
-- text-replace-0.0.0.4
+- text-replace-0.0.0.6
 - sbv-8.5
 - syz-0.2.0.0@sha256:7307acb8f6ae7720e7e235c974281ecee912703c1394ebcac19caf83d70bb492,2345
 - clock-0.8

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -12,12 +12,12 @@ packages:
   original:
     hackage: ConfigFile-1.1.4
 - completed:
-    hackage: text-replace-0.0.0.4@sha256:88800aba160dfb512cf43b24063170d34900e1646ad21f28715a22679f42ae15,1738
+    hackage: text-replace-0.0.0.6@sha256:1da9fd389da635594e65671499c045b48bc3fdd985e18a5c69cc9c9a02ad5fac,2209
     pantry-tree:
       size: 293
-      sha256: a7d17c85a9637ef9cc6762ea4e9b932191ede485655b5d18d41292cc9475b105
+      sha256: 7f7c3a17cb3a926eabdca7581e705974046137c1147c5196b72681e9477b5593
   original:
-    hackage: text-replace-0.0.0.4
+    hackage: text-replace-0.0.0.6
 - completed:
     hackage: sbv-8.5@sha256:62217ddd7a29e14e75286cba4b406187f37df63fd48f356a6639e3f9c82a18c0,19781
     pantry-tree:


### PR DESCRIPTION
Stack is configured to use lts-15.13 and `text-replace-0.0.0.4`. This leads to an error when running `stack build`:

```
Error: While constructing the build plan, the following exceptions were encountered:

In the dependencies for text-replace-0.0.0.4:
    base-4.13.0.0 from stack configuration does not match >=4.9 && <4.13  (latest matching version is 4.12.0.0)
    optparse-applicative-0.15.1.0 from stack configuration does not match >=0.12.1.0 && <0.15  (latest matching version
                                  is 0.14.3.0)
needed due to granule-frontend-0.8.1.0 -> text-replace-0.0.0.4

Some different approaches to resolving this:

  * Set 'allow-newer: true' in /home/john/.stack/config.yaml to ignore all version constraints and build anyway.

  * Build requires unattainable version of base. Since base is a part of GHC, you most likely need to use a different
    GHC version with the matching base.

Plan construction failed.
```

`text-replace-0.0.0.6` bumps the dependencies for `base` and `optparse-applicative` to versions that are available in lts-15.13