### PR TITLE
Update GHC to 9.0.2 (LTS 19.25)

### DIFF
--- a/compiler/package.yaml
+++ b/compiler/package.yaml
@@ -13,7 +13,7 @@ dependencies:
 - mtl >=2.2.1
 - optparse-applicative
 - text
-- logict == 0.7.0.2
+- logict == 0.7.1.0
 - clock
 - array
 - haskell-src-exts

--- a/frontend/package.yaml
+++ b/frontend/package.yaml
@@ -95,7 +95,7 @@ library:
   - syz >=0.2.0.0
   - text >=1.1.2
   - split
-  - logict == 0.7.0.2
+  - logict == 0.7.1.0
   - clock
 
 tests:

--- a/frontend/src/Language/Granule/Checker/Flatten.hs
+++ b/frontend/src/Language/Granule/Checker/Flatten.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 
-{-# OPTIONS_GHC -fmax-pmcheck-iterations=30000000 #-}
+{-# OPTIONS_GHC -fmax-pmcheck-models=100 #-}
 
 -- | Deals with interactions between coeffect resource algebras
 module Language.Granule.Checker.Flatten

--- a/frontend/src/Language/Granule/Syntax/Pretty.hs
+++ b/frontend/src/Language/Granule/Syntax/Pretty.hs
@@ -13,7 +13,7 @@
 module Language.Granule.Syntax.Pretty where
 
 import Data.Foldable (toList)
-import Data.List
+import Data.List (intercalate)
 import Language.Granule.Syntax.Expr
 import Language.Granule.Syntax.Type
 import Language.Granule.Syntax.Pattern

--- a/interpreter/package.yaml
+++ b/interpreter/package.yaml
@@ -18,7 +18,7 @@ dependencies:
 - mtl >=2.2.1
 - optparse-applicative
 - text
-- logict == 0.7.0.2
+- logict == 0.7.1.0
 - clock
 - array
 

--- a/repl/app/Language/Granule/Main.hs
+++ b/repl/app/Language/Granule/Main.hs
@@ -23,7 +23,6 @@ import Control.Monad.State
 import Control.Monad.Trans.Reader
 import qualified Control.Monad.Except as Ex
 import System.Console.Haskeline
-import System.Console.Haskeline.MonadException()
 
 import "Glob" System.FilePath.Glob (glob)
 import Language.Granule.Utils
@@ -267,17 +266,6 @@ synthTypeFromInputExpr exprAst = do
   case checkerResult of
     Right res -> return res
     Left err -> Ex.throwError (TypeCheckerError err (files st))
-
--- Exceptions behaviour
-instance MonadException m => MonadException (StateT ReplState m) where
-  controlIO f = StateT $ \s -> controlIO $ \(RunIO run) -> let
-                  run' = RunIO (fmap (StateT . const) . run . flip runStateT s)
-                  in fmap (flip runStateT s) $ f run'
-
-instance MonadException m => MonadException (Ex.ExceptT e m) where
-  controlIO f = Ex.ExceptT $ controlIO $ \(RunIO run) -> let
-                  run' = RunIO (fmap Ex.ExceptT . run . Ex.runExceptT)
-                  in fmap Ex.runExceptT $ f run'
 
 replEval :: (?globals :: Globals) => Int -> AST () () -> IO (Maybe RValue)
 replEval val = evalAtEntryPoint (mkId (" repl" <> show val))

--- a/runtime/package.yaml
+++ b/runtime/package.yaml
@@ -13,7 +13,7 @@ dependencies:
 - mtl >=2.2.1
 - optparse-applicative
 - text
-- logict == 0.7.0.2
+- logict == 0.7.1.0
 - clock
 - array
 - haskell-src-exts

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-15.13
+resolver: lts-19.25
 packages:
 - frontend/
 - interpreter/
@@ -11,18 +11,15 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps:
 - ConfigFile-1.1.4
-- text-replace-0.0.0.6
-- sbv-8.5
+- text-replace-0.0.0.8
+- sbv-8.17
 - syz-0.2.0.0@sha256:7307acb8f6ae7720e7e235c974281ecee912703c1394ebcac19caf83d70bb492,2345
-- clock-0.8
+- clock-0.8.3
+- optparse-applicative-0.15.1.0
 # Dependencies for language server
-- lsp-1.2.0.1@sha256:e229e53ea402947bca2e31bd33040e472509da7e1630f1ec40f52943c7227ea4,5607
-- dependent-map-0.4.0.0@sha256:ca2b131046f4340a1c35d138c5a003fe4a5be96b14efc26291ed35fd08c62221,1657
-- lsp-types-1.3.0.1@sha256:e7bd6261f0560fbbcce6c35a2ceb9cd10034896367e1c73973a4a2d85d322b0c,4689
-- constraints-extras-0.3.2.0@sha256:0897821d9d0428f41cf2179b2a8e99e0053e96a98dd39d91a31ab2851052338f,1777
-- dependent-sum-0.7.1.0@sha256:0e419237f5b86da3659772afff9cab355c0f8d5b3fdb15a5b30e673d8dc83941,2147
-- dependent-sum-template-0.1.0.3@sha256:0bbbacdfbd3abf2a15aaf0cf2c27e5bdd159b519441fec39e1e6f2f54424adde,1682
-- unliftio-core-0.2.0.1@sha256:f9abcdd3f3d28e4840563efb7b8760d2de9b5707bcd6f53a87f6a0d77bb5a9f7,1082
+- lsp-1.6.0.0
+- lsp-types-1.6.0.0
+- co-log-core-0.3.1.0
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
This pull request updates the version of GHC used by Granule from LTS 15.13 (a build of GHC 8.8.3) to LTS 19.25 (a build of GHC 9.0.2). The motivation for this was to bump us up to a version which supports the M1/M2 hardware used in the latest Macs, but it's probably good to update to a more recent release anyway regardless of this!

Changes here are mainly just telling Stack about new versions of packages, with a few other minor tweaks needed:

- in `frontend/src/Language/Granule/Checker/Flatten.hs`, the `-fmax-pmcheck-iterations` compiler flag has been deprecated, in favour of `-fmax-pmcheck-models`
- in `frontend/src/Language/Granule/Syntax/Pretty.hs`, there is now a warning for importing `Data.List` unqualified without an explicit list of imports... but we only use `intercalate` from here anyway!
- in `repl/app/Language/Granule/Main.hs`, the custom version of `MonadException` is no longer provided (or needed) in the latest versions of Haskeline
- I also took the opportunity to update the language server from using an older version of the Haskell language server protocol (lsp-1.2.0.1) to the latest version (lsp-1.6.0.0) - the API changed slightly between these versions, hence the changes in `server/app/Language/Granule/Server.hs`