### PR TITLE
Fix #195 - linearity bug

### DIFF
--- a/frontend/src/Language/Granule/Checker/Checker.hs
+++ b/frontend/src/Language/Granule/Checker/Checker.hs
@@ -1710,9 +1710,22 @@ intersectCtxtsWithWeaken s a b = do
    -- All the things that were not shared
    let remaining   = b `subtractCtxt` intersected
    let leftRemaining = a `subtractCtxt` intersected
-   weakenedRemaining <- mapM weaken remaining
-   let newCtxt = intersected <> filter isNonLinearAssumption (weakenedRemaining <> leftRemaining)
-   return . normaliseCtxt $ newCtxt
+
+   let linearNotUsedInBoth =
+         flip mapMaybe (leftRemaining <> remaining) (\(v, ass) ->
+           case ass of
+             Linear t -> Just $ LinearNotUsed v
+             _        -> Nothing)
+
+   case linearNotUsedInBoth of
+     -- All linear things used equally
+     [] -> do
+        weakenedRemaining <- mapM weaken remaining
+        let newCtxt = intersected <> filter isNonLinearAssumption (weakenedRemaining <> leftRemaining)
+        return . normaliseCtxt $ newCtxt
+
+     (p:ps) -> illLinearityMismatch s (p:|ps)
+
   where
    isNonLinearAssumption :: (Id, Assumption) -> Bool
    isNonLinearAssumption (_, Discharged _ _) = True

--- a/frontend/tests/cases/negative/graded/impossibilityCheck.gr
+++ b/frontend/tests/cases/negative/graded/impossibilityCheck.gr
@@ -1,2 +1,3 @@
+-- gr --no-eval
 bad2 : forall {n : Nat, a : Type} . a [n] -> Int
 bad2 [_] = 42

--- a/frontend/tests/cases/negative/simple/nonLinearCase.gr.output
+++ b/frontend/tests/cases/negative/simple/nonLinearCase.gr.output
@@ -1,3 +1,3 @@
 Type checking failed: 
-Linearity error: frontend/tests/cases/negative/simple/nonLinearCase.gr:4:1:
+Linearity error: frontend/tests/cases/negative/simple/nonLinearCase.gr:5:5:
 Linear variable `x` is never used.

--- a/frontend/tests/cases/negative/simple/useFollowedByCase.gr
+++ b/frontend/tests/cases/negative/simple/useFollowedByCase.gr
@@ -1,0 +1,3 @@
+data Bool = True | False
+bug : Int -> Int
+bug x = let () = drop@ Int x in (if True then x else 7)

--- a/frontend/tests/cases/negative/simple/useFollowedByCase.gr.output
+++ b/frontend/tests/cases/negative/simple/useFollowedByCase.gr.output
@@ -1,0 +1,3 @@
+Type checking failed: 
+Linearity error: frontend/tests/cases/negative/simple/useFollowedByCase.gr:3:34:
+Linear variable `x` is never used.

--- a/frontend/tests/cases/positive/indexed/fewerAnnotations.gr
+++ b/frontend/tests/cases/positive/indexed/fewerAnnotations.gr
@@ -8,4 +8,4 @@ vmap [f] (Cons x xs) = Cons (f x) (vmap [f] xs)
 
 main : Vec 3 Int
 -- Tests the approach for having fewer annotations on lambdas
-main = map [λx → x + 1] (Cons 1 (Cons 2 (Cons 3 Nil)))
+main = vmap [λx → x + 1] (Cons 1 (Cons 2 (Cons 3 Nil)))

--- a/interpreter/tests/Golden.hs
+++ b/interpreter/tests/Golden.hs
@@ -64,7 +64,7 @@ main = do
       -- go into project root
       setCurrentDirectory "../"
       negative  <- goldenTestsNegative  config
-      positive  <- goldenTestsPositive  config 
+      positive  <- goldenTestsPositive  config
       rewrite   <- goldenTestsRewrite   config
       synthesis <- goldenTestsSynthesis config
 
@@ -193,7 +193,7 @@ goldenTestsSynthesis config = do
 
   return $ testGroup
     "Golden synthesis examples"
-    [testGroup 
+    [testGroup
        "Main: Additive" (map (grGolden' mainGlobals) files)
     -- Do extra tests, running additive pruning and subtractive on the hilbert benchmarks
    , testGroup
@@ -207,7 +207,8 @@ goldenTestsSynthesis config = do
         globalsSourceFilePath = Just fp,
         globalsSynthesise = Just True,
         globalsRewriteHoles = Just True,
-        globalsIncludePath = Just "StdLib" }
+        globalsIncludePath = Just "StdLib",
+        globalsSynthTimeoutMillis = Just 3000 }
 
     subtractiveGlobals :: FilePath -> Globals
     subtractiveGlobals fp = (mainGlobals fp) { globalsSubtractiveSynthesis = Just True }


### PR DESCRIPTION
We were missing an all important check in `joinCtxts` where we should be complaining if we spot any linear variables that appear in one context but not the other. Somehow this bug survived since a long time ago!