### PR TITLE
Dual is involution

### DIFF
--- a/frontend/src/Language/Granule/Checker/Types.hs
+++ b/frontend/src/Language/Granule/Checker/Types.hs
@@ -342,7 +342,7 @@ equalTypesRelatedCoeffectsInner s rel (Star g1 t1) t2 _ sp mode
     (g, _, u) <- equalTypes s t1 t2
     return (g, u)
 
-equalTypesRelatedCoeffectsInner s rel t1 (Star g2 t2) k sp mode = 
+equalTypesRelatedCoeffectsInner s rel t1 (Star g2 t2) k sp mode =
   equalTypesRelatedCoeffectsInner s rel (Star g2 t2) t1 k (flipIndicator sp) mode
 
 -- Do duality check (left) [special case of TyApp rule]
@@ -585,6 +585,17 @@ isDualSession :: (?globals :: Globals)
     -- Indicates whether the first type or second type is a specification
     -> SpecIndicator
     -> Checker (Bool, Substitution)
+-- asking if `t` is dual to `Dual t'`
+-- therefore turn this into `t == t'`
+-- This deals with the case where `equalTypes` has asked
+-- if `t == Dual (Dual t')`
+isDualSession sp rel t (TyApp (TyCon c) t') ind =
+  equalTypesRelatedCoeffectsInner sp rel t t' (TyCon $ mkId "Protocol") ind Types
+-- and symmetric of the above:
+isDualSession sp rel (TyApp (TyCon c) t) t' ind =
+  equalTypesRelatedCoeffectsInner sp rel t t' (TyCon $ mkId "Protocol") ind Types
+
+-- Send/receive duality
 isDualSession sp rel (TyApp (TyApp (TyCon c) t) s) (TyApp (TyApp (TyCon c') t') s') ind
   |  (internalName c == "Send" && internalName c' == "Recv")
   || (internalName c == "Recv" && internalName c' == "Send") = do

--- a/frontend/tests/cases/negative/graded/impossibilityCheck.gr
+++ b/frontend/tests/cases/negative/graded/impossibilityCheck.gr
@@ -1,2 +1,3 @@
+-- gr --no-eval
 bad2 : forall {n : Nat, a : Type} . a [n] -> Int
 bad2 [_] = 42

--- a/frontend/tests/cases/positive/concurrent/dual-involution.gr
+++ b/frontend/tests/cases/positive/concurrent/dual-involution.gr
@@ -1,0 +1,5 @@
+-- Flip the position of duality for the forkLinear
+-- primitive
+forkLinearAlt : forall {s : Protocol}
+    . (LChan (Dual s) -> ()) -> LChan s
+forkLinearAlt = forkLinear

--- a/frontend/tests/cases/positive/indexed/fewerAnnotations.gr
+++ b/frontend/tests/cases/positive/indexed/fewerAnnotations.gr
@@ -8,4 +8,4 @@ vmap [f] (Cons x xs) = Cons (f x) (vmap [f] xs)
 
 main : Vec 3 Int
 -- Tests the approach for having fewer annotations on lambdas
-main = map [λx → x + 1] (Cons 1 (Cons 2 (Cons 3 Nil)))
+main = vmap [λx → x + 1] (Cons 1 (Cons 2 (Cons 3 Nil)))


### PR DESCRIPTION
Noticed we don't deal well with the involutive behaviour of `Dual`. For example the following would not type check:
```
forkLinearAlt : forall {s : Protocol}
    . (LChan (Dual s) -> ()) -> LChan s
forkLinearAlt = forkLinear
```
This PR fixes this (and adds the above as a test).