### PR TITLE
initial Nix build, Docker image for repl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,10 +57,15 @@ Temporary Items
 *.bak
 
 # Cabal files, because we are using hpack
-*.cabal
+# TODO 2023-07-20 raehik: committing Cabal files is handy and suggested by the
+# creator of Stack: https://www.fpcomplete.com/blog/storing-generated-cabal-files/
+#*.cabal
 
 # Compiler Examples
 compiler-examples/
 
 # VSCode
 .vscode
+
+# Nix
+/result

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,7 @@
+packages:
+    ./frontend
+    ./interpreter
+    ./repl
+    ./server
+    ./compiler
+    ./runtime

--- a/compiler/granule-compiler.cabal
+++ b/compiler/granule-compiler.cabal
@@ -1,0 +1,89 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.35.2.
+--
+-- see: https://github.com/sol/hpack
+
+name:           granule-compiler
+version:        0.1.0.0
+author:         Michael Vollmer
+maintainer:     Michael Vollmer
+build-type:     Simple
+
+library
+  exposed-modules:
+      Language.Granule.Compiler.Error
+      Language.Granule.Compiler.HSCodegen
+      Language.Granule.Compiler.Util
+  other-modules:
+      Paths_granule_compiler
+  hs-source-dirs:
+      src
+  default-extensions:
+      LambdaCase
+      RecordWildCards
+      ImplicitParams
+      ScopedTypeVariables
+      OverloadedStrings
+      FlexibleContexts
+      ConstraintKinds
+  ghc-options: -Wall -Werror -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -Wno-unused-matches -Wno-name-shadowing -Wno-type-defaults
+  build-depends:
+      Glob
+    , array
+    , base >=4.10 && <5
+    , clock
+    , containers
+    , criterion
+    , directory
+    , extra
+    , filepath
+    , gitrev
+    , granule-frontend
+    , granule-runtime
+    , haskell-src-exts
+    , logict >=0.7.1.0
+    , mtl >=2.2.1
+    , optparse-applicative
+    , silently
+    , text
+    , time
+  default-language: Haskell2010
+
+executable grc
+  main-is: Language/Granule/Compiler.hs
+  other-modules:
+      Paths_granule_compiler
+  hs-source-dirs:
+      app
+  default-extensions:
+      LambdaCase
+      RecordWildCards
+      ImplicitParams
+      ScopedTypeVariables
+      OverloadedStrings
+      FlexibleContexts
+      ConstraintKinds
+  ghc-options: -Wall -Werror -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -Wno-unused-matches -Wno-name-shadowing -Wno-type-defaults -main-is Language.Granule.Compiler
+  build-depends:
+      Glob
+    , array
+    , base >=4.10 && <5
+    , clock
+    , containers
+    , criterion
+    , directory
+    , extra
+    , filepath
+    , gitrev
+    , granule-compiler
+    , granule-frontend
+    , granule-runtime
+    , haskell-src-exts
+    , logict >=0.7.1.0
+    , mtl >=2.2.1
+    , optparse-applicative
+    , silently
+    , text
+    , time
+  default-language: Haskell2010

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,80 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1685662779,
+        "narHash": "sha256-cKDDciXGpMEjP1n6HlzKinN0H+oLmNpgeCTzYnsA2po=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "71fb97f0d875fd4de4994dfb849f2c75e17eb6c3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "haskell-flake": {
+      "locked": {
+        "lastModified": 1687375904,
+        "narHash": "sha256-cBLffqOaf77zj+d/zYL27ti4MX7mOCTMrJrue7l5Muk=",
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "rev": "ab43c9d07efeaaeafd89c0ba371651340b52147d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1687488839,
+        "narHash": "sha256-7JDjuyHwUvGJJge9jxfRJkuYyL5G5yipspc4J3HwjGA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "f9e94676ce6c7531c44d38da61d2669ebec0f603",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1685564631,
+        "narHash": "sha256-8ywr3AkblY4++3lIVxmrWZFzac7+f32ZEhH/A8pNscI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4f53efe34b3a8877ac923b9350c874e3dcd5dc0a",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "haskell-flake": "haskell-flake",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,61 @@
+# TODO 2023-07-20T22:19:36+0100 raehik
+# * they build with GHC 9.2.5 (check Stack resolver in stack.yaml I guess)
+# * granule-interpreter/gr-golden had 7 fails (tests disabled here)
+
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    haskell-flake.url = "github:srid/haskell-flake";
+  };
+  outputs = inputs@{ self, nixpkgs, flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = nixpkgs.lib.systems.flakeExposed;
+      imports = [ inputs.haskell-flake.flakeModule ];
+
+      perSystem = { self', pkgs, config, ... }: {
+        packages.default = self'.packages.granule-repl;
+        #haskellProjects.ghc96 = import ./haskell-flake-ghc96.nix pkgs;
+        haskellProjects.default = {
+          #basePackages = config.haskellProjects.ghc96.outputs.finalPackages;
+          settings = {
+            sbv = {
+              # 2023-04-18 raehik: sbv-9.0 broken; seems tests fail. ignore
+              check = false;
+              broken = false;
+            };
+
+            granule-interpreter = {
+              # TODO 2023-07-20 raehik: accesses files outside directory
+              check = false;
+            };
+          };
+
+          devShell = {
+            tools = hp: {
+              ghcid = null; # broken on GHC 9.6? old fsnotify
+              hlint = null; # broken on GHC 9.6? old
+              haskell-language-server = null; # TAKES AGES TO BUILD FFS
+            };
+          };
+        };
+
+        # `nix build .#image` preps a Docker/OSI image build
+        # uses streamLayeredImage so as to not place the image in the Nix store
+        # to use, run result script and load into your container daemon. e.g.
+        # for podman, `nix build .#image && ./result | podman load`
+        packages.image = pkgs.dockerTools.streamLayeredImage {
+          name = "granule-repl";
+          # equivalent to `git rev-parse HEAD`
+          # only exists on clean working tree, else set to "dev"
+          tag = self.rev or "dev";
+          config = {
+            Entrypoint = [ "${pkgs.lib.getExe self'.packages.granule-repl}" ];
+          };
+          #contents = [ self'.packages.granule-repl ];
+          maxLayers = 100; # less than Docker max layers to allow extending
+        };
+
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,8 @@
         # uses streamLayeredImage so as to not place the image in the Nix store
         # to use, run result script and load into your container daemon. e.g.
         # for podman, `nix build .#image && ./result | podman load`
+        # for some reason, I don't need justStaticExecutables to get a small
+        # image here. not sure why but sure!
         packages.image = pkgs.dockerTools.streamLayeredImage {
           name = "granule-repl";
           # equivalent to `git rev-parse HEAD`

--- a/frontend/granule-frontend.cabal
+++ b/frontend/granule-frontend.cabal
@@ -1,0 +1,144 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.35.2.
+--
+-- see: https://github.com/sol/hpack
+
+name:           granule-frontend
+version:        0.9.3.0
+synopsis:       The Granule abstract-syntax-tree, parser and type checker libraries
+homepage:       https://github.com/granule-project/granule#readme
+bug-reports:    https://github.com/granule-project/granule/issues
+author:         Dominic Orchard, Vilem-Benjamin Liepelt, Harley Eades III, Jack Hughes, Preston Keel, Daniel Marshall, Michael Vollmer
+maintainer:     Dominic Orchard, Vilem-Benjamin Liepelt, Harley Eades III, Jack Hughes, Preston Keel, Daniel Marshall, Michael Vollmer
+copyright:      2018-22 authors
+license:        BSD3
+build-type:     Simple
+
+source-repository head
+  type: git
+  location: https://github.com/granule-project/granule
+
+library
+  exposed-modules:
+      Data.Bifunctor.Foldable
+      Language.Granule.Checker.Checker
+      Language.Granule.Checker.Coeffects
+      Language.Granule.Checker.Constraints
+      Language.Granule.Checker.Constraints.SNatX
+      Language.Granule.Checker.DataTypes
+      Language.Granule.Checker.Flatten
+      Language.Granule.Checker.Ghost
+      Language.Granule.Checker.LaTeX
+      Language.Granule.Checker.Monad
+      Language.Granule.Checker.Patterns
+      Language.Granule.Checker.Predicates
+      Language.Granule.Checker.Primitives
+      Language.Granule.Checker.Kinding
+      Language.Granule.Checker.Substitution
+      Language.Granule.Checker.SubstitutionContexts
+      Language.Granule.Checker.TypeAliases
+      Language.Granule.Checker.Types
+      Language.Granule.Syntax.Def
+      Language.Granule.Syntax.Expr
+      Language.Granule.Syntax.Helpers
+      Language.Granule.Syntax.FirstParameter
+      Language.Granule.Syntax.Annotated
+      Language.Granule.Syntax.Identifiers
+      Language.Granule.Syntax.Lexer
+      Language.Granule.Syntax.Parser
+      Language.Granule.Syntax.Pattern
+      Language.Granule.Syntax.Pretty
+      Language.Granule.Syntax.Preprocessor
+      Language.Granule.Syntax.Preprocessor.Ascii
+      Language.Granule.Syntax.Preprocessor.Latex
+      Language.Granule.Syntax.Preprocessor.Markdown
+      Language.Granule.Syntax.Span
+      Language.Granule.Syntax.Type
+      Language.Granule.Synthesis.Splitting
+      Language.Granule.Synthesis.RewriteHoles
+      Language.Granule.Context
+      Language.Granule.Utils
+  other-modules:
+      Language.Granule.Checker.CoeffectsTypeConverter
+      Language.Granule.Checker.Constraints.Compile
+      Language.Granule.Checker.Constraints.SymbolicGrades
+      Language.Granule.Checker.Effects
+      Language.Granule.Checker.Exhaustivity
+      Language.Granule.Checker.NameClash
+      Language.Granule.Checker.Normalise
+      Language.Granule.Checker.Simplifier
+      Language.Granule.Checker.Variables
+      Language.Granule.Syntax.SecondParameter
+      Language.Granule.Synthesis.Builders
+      Language.Granule.Synthesis.Deriving
+      Language.Granule.Synthesis.Monad
+      Language.Granule.Synthesis.Refactor
+      Language.Granule.Synthesis.Synth
+      Text.Reprinter
+      Paths_granule_frontend
+  hs-source-dirs:
+      src
+  default-extensions:
+      ImplicitParams
+      ViewPatterns
+      LambdaCase
+      TupleSections
+      NamedFieldPuns
+  ghc-options: -O0 -Wall -Werror -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -Wno-unused-matches -Wno-name-shadowing -Wno-type-defaults -fno-warn-unticked-promoted-constructors
+  build-tools:
+      alex
+    , happy
+  build-depends:
+      Glob
+    , array
+    , base >=4.10 && <5
+    , bifunctors
+    , clock
+    , containers
+    , directory
+    , filepath
+    , logict >=0.7.1.0
+    , mtl >=2.2.1
+    , raw-strings-qq
+    , sbv >=8.5
+    , split
+    , syb >=0.6
+    , syz >=0.2.0.0
+    , text >=1.1.2
+    , text-replace
+    , time
+    , transformers >=0.5
+  default-language: Haskell2010
+
+test-suite frontend-spec
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Data.Bifunctor.FoldableSpec
+      Language.Granule.Checker.CheckerSpec
+      Language.Granule.Checker.MonadSpec
+      Language.Granule.Checker.SubstitutionsSpec
+      Language.Granule.Checker.TypesSpec
+      Language.Granule.Syntax.ExprSpec
+      Language.Granule.Synthesis.SplittingSpec
+      Paths_granule_frontend
+  hs-source-dirs:
+      tests/hspec
+  default-extensions:
+      ImplicitParams
+      ViewPatterns
+      LambdaCase
+      TupleSections
+      NamedFieldPuns
+  ghc-options: -O0 -Wall -Werror -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -Wno-unused-matches -Wno-name-shadowing -Wno-type-defaults -fno-warn-unticked-promoted-constructors -fno-warn-partial-type-signatures
+  build-depends:
+      QuickCheck
+    , base >=4.10 && <5
+    , bifunctors
+    , containers
+    , granule-frontend
+    , hspec
+    , mtl
+    , transformers >=0.5
+  default-language: Haskell2010

--- a/haskell-flake-ghc96.nix
+++ b/haskell-flake-ghc96.nix
@@ -1,0 +1,49 @@
+pkgs:
+
+{
+  # disable local project options (always do this for package sets)
+  defaults.packages = {};
+  devShell.enable = false;
+  autoWire = [];
+
+  basePackages = pkgs.haskell.packages.ghc96;
+
+  packages = { #self: super: with pkgs.haskell.lib; {
+    # 2023-04-17 raehik: need hedgehog 1.2 for GHC 9.6
+    hedgehog.source = "1.2";
+    tasty-hedgehog.source = "1.4.0.1";
+
+    # 2023-04-17 raehik: warp: need new for GHC 9.6 (unix-2.8)
+    # also has 3 test failures. idk why. disabling
+    # also has friends that need swapping out. heck on earth
+    warp.source = "3.3.25";
+    recv.source = "0.1.0";
+    warp-tls.source = "3.3.6";
+  };
+
+  settings = {
+
+    hourglass = {
+      # 2023-04-17 raehik: hourglass tests broken from GHC 9.2.5
+      # PR: https://github.com/vincenthz/hs-hourglass/pull/56
+      check = false;
+    };
+
+    bsb-http-chunked = {
+      # 2023-04-17 raehik: bsb-http-chunked: tests broken
+      # maybe problematic type wildcard usage...?
+      check = false;
+    };
+
+    doctest-exitcode-stdio = {
+      # 2023-04-26 raehik: weird bug. bad test.
+      jailbreak = true;
+    };
+
+    warp = {
+      check = false;
+    };
+
+  };
+
+}

--- a/interpreter/granule-interpreter.cabal
+++ b/interpreter/granule-interpreter.cabal
@@ -1,0 +1,127 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.35.2.
+--
+-- see: https://github.com/sol/hpack
+
+name:           granule-interpreter
+version:        0.9.3.0
+synopsis:       The Granule interpreter
+homepage:       https://github.com/dorchard/granule#readme
+bug-reports:    https://github.com/dorchard/granule/issues
+author:         Dominic Orchard, Vilem-Benjamin Liepelt, Harley Eades III, Jack Hughes, Preston Keel, Daniel Marshall, Michael Vollmer
+maintainer:     Dominic Orchard, Vilem-Benjamin Liepelt, Harley Eades III, Jack Hughes, Preston Keel, Daniel Marshall, Michael Vollmer
+copyright:      2018-22 authors
+license:        BSD3
+build-type:     Simple
+
+source-repository head
+  type: git
+  location: https://github.com/dorchard/granule
+
+library
+  exposed-modules:
+      Language.Granule.Interpreter
+      Language.Granule.Interpreter.Eval
+      Language.Granule.Interpreter.Desugar
+  other-modules:
+      Language.Granule.Doc
+      Paths_granule_interpreter
+  hs-source-dirs:
+      src
+  default-extensions:
+      LambdaCase
+      RecordWildCards
+      ImplicitParams
+      ScopedTypeVariables
+      OverloadedStrings
+  ghc-options: -O0 -Wall -Werror -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -Wno-unused-matches -Wno-name-shadowing -Wno-type-defaults
+  build-depends:
+      Glob
+    , array
+    , base >=4.10 && <5
+    , clock
+    , concurrent-extra
+    , directory
+    , extra
+    , filepath
+    , gitrev
+    , granule-frontend
+    , granule-runtime
+    , logict >=0.7.1.0
+    , mtl >=2.2.1
+    , optparse-applicative
+    , text
+  default-language: Haskell2010
+
+executable gr
+  main-is: Language/Granule/Interpreter.hs
+  other-modules:
+      Language.Granule.Doc
+      Language.Granule.Interpreter.Desugar
+      Language.Granule.Interpreter.Eval
+      Paths_granule_interpreter
+  hs-source-dirs:
+      src
+  default-extensions:
+      LambdaCase
+      RecordWildCards
+      ImplicitParams
+      ScopedTypeVariables
+      OverloadedStrings
+  ghc-options: -O0 -Wall -Werror -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -Wno-unused-matches -Wno-name-shadowing -Wno-type-defaults -main-is Language.Granule.Interpreter
+  build-depends:
+      Glob
+    , array
+    , base >=4.10 && <5
+    , clock
+    , concurrent-extra
+    , directory
+    , extra
+    , filepath
+    , gitrev
+    , granule-frontend
+    , granule-interpreter
+    , granule-runtime
+    , logict >=0.7.1.0
+    , mtl >=2.2.1
+    , optparse-applicative
+    , text
+  default-language: Haskell2010
+
+test-suite gr-golden
+  type: exitcode-stdio-1.0
+  main-is: Golden.hs
+  other-modules:
+      Paths_granule_interpreter
+  hs-source-dirs:
+      tests
+  default-extensions:
+      LambdaCase
+      RecordWildCards
+      ImplicitParams
+      ScopedTypeVariables
+      OverloadedStrings
+  ghc-options: -O0 -Wall -Werror -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -Wno-unused-matches -Wno-name-shadowing -Wno-type-defaults
+  build-depends:
+      Diff
+    , Glob
+    , array
+    , base >=4.10 && <5
+    , clock
+    , concurrent-extra
+    , directory
+    , extra
+    , filepath
+    , gitrev
+    , granule-frontend
+    , granule-interpreter
+    , granule-runtime
+    , logict >=0.7.1.0
+    , mtl >=2.2.1
+    , optparse-applicative
+    , strict
+    , tasty
+    , tasty-golden
+    , text
+  default-language: Haskell2010

--- a/repl/granule-repl.cabal
+++ b/repl/granule-repl.cabal
@@ -1,0 +1,47 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.35.2.
+--
+-- see: https://github.com/sol/hpack
+
+name:           granule-repl
+version:        0.9.3.0
+synopsis:       The Granule interactive interpreter (grepl)
+homepage:       https://github.com/dorchard/granule#readme
+bug-reports:    https://github.com/dorchard/granule/issues
+author:         Dominic Orchard, Vilem-Benjamin Liepelt, Harley Eades III, Preston Keel
+maintainer:     Dominic Orchard, Vilem-Benjamin Liepelt, Harley Eades III, Preston Keel
+copyright:      2019 authors
+license:        BSD3
+build-type:     Simple
+
+source-repository head
+  type: git
+  location: https://github.com/dorchard/granule
+
+executable grepl
+  main-is: Language/Granule/Main.hs
+  other-modules:
+      Language.Granule.Queue
+      Language.Granule.ReplError
+      Language.Granule.ReplParser
+      Paths_granule_repl
+  hs-source-dirs:
+      app
+  ghc-options: -O3 -W -Werror -Wno-unused-matches
+  build-depends:
+      Glob
+    , base >=4.10 && <5
+    , clock >=0.8
+    , containers
+    , directory
+    , filemanip
+    , filepath
+    , granule-frontend
+    , granule-interpreter
+    , haskeline
+    , mtl >=2.2.1
+    , parsec
+    , text
+    , transformers >=0.5
+  default-language: Haskell2010

--- a/runtime/granule-runtime.cabal
+++ b/runtime/granule-runtime.cabal
@@ -1,0 +1,48 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.35.2.
+--
+-- see: https://github.com/sol/hpack
+
+name:           granule-runtime
+version:        0.1.0.0
+author:         Michael Vollmer
+maintainer:     Michael Vollmer
+build-type:     Simple
+
+library
+  exposed-modules:
+      Language.Granule.Runtime
+  other-modules:
+      Paths_granule_runtime
+  hs-source-dirs:
+      src
+  default-extensions:
+      LambdaCase
+      RecordWildCards
+      ImplicitParams
+      ScopedTypeVariables
+      OverloadedStrings
+      FlexibleContexts
+      ConstraintKinds
+  ghc-options: -Wall -Werror -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -Wno-unused-matches -Wno-name-shadowing -Wno-type-defaults
+  build-depends:
+      Glob
+    , array
+    , base >=4.10 && <5
+    , clock
+    , containers
+    , criterion
+    , directory
+    , extra
+    , filepath
+    , gitrev
+    , granule-frontend
+    , haskell-src-exts
+    , logict >=0.7.1.0
+    , mtl >=2.2.1
+    , optparse-applicative
+    , silently
+    , text
+    , time
+  default-language: Haskell2010

--- a/server/granule-language-server.cabal
+++ b/server/granule-language-server.cabal
@@ -1,0 +1,37 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.35.2.
+--
+-- see: https://github.com/sol/hpack
+
+name:           granule-language-server
+version:        0.9.3.0
+synopsis:       The Granule language server (grls)
+author:         Daniel Marshall
+maintainer:     Daniel Marshall
+build-type:     Simple
+
+executable grls
+  main-is: Language/Granule/Server.hs
+  other-modules:
+      Paths_granule_language_server
+  hs-source-dirs:
+      app
+  ghc-options: -O3 -W -Werror -Wno-unused-matches -main-is Language.Granule.Server
+  build-depends:
+      Glob
+    , base
+    , clock >=0.8
+    , containers
+    , data-default
+    , directory
+    , filepath
+    , granule-frontend
+    , granule-interpreter
+    , lens
+    , lsp
+    , mtl >=2.2.1
+    , split
+    , text
+    , transformers
+  default-language: Haskell2010


### PR DESCRIPTION
I have convenient slim Docker image generation with no funny business (no Dockerfile!) over on [camfort/camfort](https://github.com/camfort/camfort). It leverages the [Nix package manager](https://nixos.org/), which I+the CI already use to build. @dorchard expressed interest in doing the same for Granule.

Some notes:

* I add a `cabal.project` because Nix builds with Cabal: nice and simple thankfully
* I commit `*.cabal` files because Nix needs them in repo. Stack creator recommends this practice as of a few years ago: https://www.fpcomplete.com/blog/storing-generated-cabal-files/
* This is easily shoved into a CI job so no one has to look at Nix or wrangle images unless (well, until) the build breaks. See: https://github.com/camfort/camfort/blob/d4f8008b720b67e8fe8ddf9f4158c11fa5c405c3/.github/workflows/nix.yaml (I never wrote automated image managing, so you'd still have to retag stuff, but it's complete otherwise.)