### PR TITLE
Fixes bug in `flatten` for `Sec`

### DIFF
--- a/frontend/src/Language/Granule/Checker/Kinding.hs
+++ b/frontend/src/Language/Granule/Checker/Kinding.hs
@@ -945,8 +945,8 @@ flattenable t1 t2
     t1 | t1 == extendedNat -> return $ Just (TyInfix TyOpTimes, [], t1)
 
     TyCon (internalName -> "Nat")   -> return $ Just (TyInfix TyOpTimes, [], t1)
-    TyCon (internalName -> "Level") -> return $ Just (TyInfix TyOpMeet, [], t1)
-    TyCon (internalName -> "Sec") -> return $ Just (TyInfix TyOpMeet, [], t1)
+    TyCon (internalName -> "Level") | SecurityLevels `elem` globalsExtensions ?globals -> return $ Just (TyInfix TyOpMeet, [], t1)
+    TyCon (internalName -> "Sec") -> return $ Just (TyInfix TyOpTimes, [], t1)
 
     TyApp (TyCon (internalName -> "Interval")) t ->  flattenable t t
 

--- a/frontend/tests/cases/negative/flatten/flattenLevel.gr
+++ b/frontend/tests/cases/negative/flatten/flattenLevel.gr
@@ -1,2 +1,0 @@
-flattenLevel : ∀ { k : Sec, l : Sec } . (Int [k]) [l] → Int [k ∨ l]
-flattenLevel [[x]] = [x]

--- a/frontend/tests/cases/negative/flatten/flattenLevel.gr.output
+++ b/frontend/tests/cases/negative/flatten/flattenLevel.gr.output
@@ -1,7 +1,0 @@
-Type checking failed: 
-Counter example: frontend/tests/cases/negative/flatten/flattenLevel.gr:2:1:
-  When checking `flattenLevel`, l ∧ k value cannot be moved to level (k ∨ l) * (1 : Level)
-
-Counter-example:
-  l = 0 :: Level
-  k = 0 :: Level

--- a/frontend/tests/cases/negative/flatten/flattenSec.gr
+++ b/frontend/tests/cases/negative/flatten/flattenSec.gr
@@ -1,0 +1,8 @@
+leak : forall {a : Type} . a [Private] -> a [Public]
+leak x = join (split x)
+
+split : forall {a : Type} . a [Private] -> (a [Private]) [Public]
+split [x] = [[x]]
+
+join : forall {a : Type} . (a [Private]) [Public] -> a [Public]
+join [[x]] = [x]

--- a/frontend/tests/cases/negative/flatten/flattenSec.gr.output
+++ b/frontend/tests/cases/negative/flatten/flattenSec.gr.output
@@ -1,0 +1,3 @@
+Type checking failed: 
+Falsifiable theorem: frontend/tests/cases/negative/flatten/flattenSec.gr:8:1:
+  When checking `join`, public is not approximatable by Public * Private for type Sec

--- a/frontend/tests/cases/positive/security/flattenSec.gr
+++ b/frontend/tests/cases/positive/security/flattenSec.gr
@@ -1,4 +1,4 @@
-flatten : ∀ {k : Sec, l : Sec} . (Int [k]) [l] → Int [k ∧ l]
+flatten : ∀ {k : Sec, l : Sec} . (Int [k]) [l] → Int [k * l]
 flatten [[x]] = [x]
 
 xbb : (Int [Lo]) [Hi]


### PR DESCRIPTION
This fixes issue https://github.com/granule-project/granule/issues/223 where the flatten operation for `Sec` was set to "meet" which only works for `Level` not `Sec` (there was some accidental conflation between the two here  which is not separated by the `SecurityLevels` pragma). 