### PR TITLE
Fixes issue #190 - where we had a bug in the evaluator because of name clash

### DIFF
--- a/frontend/src/Language/Granule/Checker/Primitives.hs
+++ b/frontend/src/Language/Granule/Checker/Primitives.hs
@@ -757,6 +757,12 @@ cap = BUILTIN
 -- trace : String -> () <>
 -- trace = BUILTIN
 
+------------------------------
+-- Debugging routines
+------------------------------
+-- debug : forall {a : Type} . String -> a -> a
+-- debug = BUILTIN
+
 |]
 
 

--- a/frontend/tests/cases/negative/indexed/variableNotInResult.gr
+++ b/frontend/tests/cases/negative/indexed/variableNotInResult.gr
@@ -1,2 +1,3 @@
+data Vec n a = None
 data VecX (a : Type) where
   VecX : ∀ {n : Nat} . Vec n a → VecX a

--- a/frontend/tests/cases/negative/indexed/variableNotInResult.gr
+++ b/frontend/tests/cases/negative/indexed/variableNotInResult.gr
@@ -1,3 +1,3 @@
-data Vec n a = None
+data Vec (n : Nat) a = Blank
 data VecX (a : Type) where
   VecX : ∀ {n : Nat} . Vec n a → VecX a

--- a/frontend/tests/cases/positive/simple/hoeval.gr
+++ b/frontend/tests/cases/positive/simple/hoeval.gr
@@ -1,0 +1,42 @@
+import List
+import Maybe
+
+data Parser (a : Type) = Parser (String → List (a , String))
+
+parse : ∀ {a : Type}. Parser a → String → List (a , String)
+parse (Parser p) = p
+
+result : ∀{a : Type}. a → Parser a
+result a = Parser (λs → Next (a,s) Empty)
+
+concat : ∀{a : Type}. List (List a) → List a
+concat Empty = Empty;
+concat (Next xs xss) = append_list xs (concat xss)
+
+bind : ∀{a b : Type}. Parser a → (a → Parser b)[] → Parser b
+bind (Parser p) [f] = Parser (λ s → concat(lmap [λ(a,s') → parse (f a) s'] (p s)))
+
+zero : ∀{a : Type}. Parser a
+zero = Parser (λ s → let () = drop @String s in Empty)
+
+item : Parser Char
+item = Parser (λ s → case stringUncons s of
+                        Nothing → Empty;
+                        Just (c,cs) → Next (c,cs) Empty)
+
+
+sat : (Char → Bool)[] → Parser Char
+sat [p] = item `bind` [λ c →  let
+                                [c'] : Char[] = moveChar c
+                              in  if (p c')
+                                  then (result c')
+                                  else zero]
+
+lookup : List Char → Char → Bool
+lookup Empty c = let () = drop @Char c in False;
+lookup (Next c' cs) c = let
+                          [c] : Char[] = moveChar c
+                        in (c ≡ c') `or'` (lookup cs c)
+
+main : List (Char, String)
+main = parse (sat [lookup (Next 'h' Empty)]) "h"

--- a/frontend/tests/cases/positive/simple/hoeval.gr.output
+++ b/frontend/tests/cases/positive/simple/hoeval.gr.output
@@ -1,0 +1,1 @@
+Next ('h', "") Empty

--- a/interpreter/src/Language/Granule/Interpreter/Desugar.hs
+++ b/interpreter/src/Language/Granule/Interpreter/Desugar.hs
@@ -59,11 +59,11 @@ desugar (Def s var rf spec eqs tys@(Forall _ _ _ ty)) =
       where
         numArgs =
           case eqs of
-            ((Equation _ _ _ _ ps _):_) -> length ps
+            ((Equation s _ _ _ ps _):_) -> length ps
             _                         -> 0
 
-        -- List of variables to represent each argument
-        vars = [mkId (" internal" ++ show i) | i <- [1..numArgs]]
+        -- List of variables (uniquely named via the span) to represent each argument
+        vars = [mkId (" internal" ++ show (startPos s) ++ show i) | i <- [1..numArgs]]
 
         -- Guard expression
         guard = foldl pair unitVal guardVars

--- a/interpreter/src/Language/Granule/Interpreter/Eval.hs
+++ b/interpreter/src/Language/Granule/Interpreter/Eval.hs
@@ -790,6 +790,11 @@ builtIns =
   , (mkId "gsend",    Ext () $ Primitive gsend)
   , (mkId "gclose",   Ext () $ Primitive gclose)
   -- , (mkId "trace",   Ext () $ Primitive $ \(StringLiteral s) -> diamondConstr $ do { Text.putStr s; hFlush stdout; return $ Val nullSpan () False (Constr () (mkId "()") []) })
+  -- , (mkId "trace",   Ext () $ Primitive $ \(StringLiteral s) -> do
+  --                         return $ Ext () $ Primitive $ \e -> do
+  --                                               putStrLn $ "TRACE<" <> unpack s <> ">: " <> pretty e <> "\n"
+  --                                               return e )
+
   -- , (mkId "newPtr", malloc)
   -- , (mkId "swapPtr", peek poke castPtr) -- hmm probably don't need to cast the Ptr
   -- , (mkId "freePtr", free)

--- a/interpreter/src/Language/Granule/Interpreter/Eval.hs
+++ b/interpreter/src/Language/Granule/Interpreter/Eval.hs
@@ -753,8 +753,8 @@ builtIns =
           Ext () $ Primitive $ \(StringLiteral t) -> return $ StringLiteral $ s `RT.stringAppend` t)
   , ( mkId "stringUncons"
     , Ext () $ Primitive $ \(StringLiteral s) -> return $ case uncons s of
-        Just (c, s) -> Constr () (mkId "Some") [Constr () (mkId ",") [CharLiteral c, StringLiteral s]]
-        Nothing     -> Constr () (mkId "None") []
+        Just (c, s) -> Constr () (mkId "Just") [Constr () (mkId ",") [CharLiteral c, StringLiteral s]]
+        Nothing     -> Constr () (mkId "Nothing") []
     )
   , ( mkId "stringCons"
     , Ext () $ Primitive $ \(CharLiteral c) -> return $
@@ -762,8 +762,8 @@ builtIns =
     )
   , ( mkId "stringUnsnoc"
     , Ext () $ Primitive $ \(StringLiteral s) -> return $ case unsnoc s of
-        Just (s, c) -> Constr () (mkId "Some") [Constr () (mkId ",") [StringLiteral s, CharLiteral c]]
-        Nothing     -> Constr () (mkId "None") []
+        Just (s, c) -> Constr () (mkId "Just") [Constr () (mkId ",") [StringLiteral s, CharLiteral c]]
+        Nothing     -> Constr () (mkId "Nothing") []
     )
   , ( mkId "stringSnoc"
     , Ext () $ Primitive $ \(StringLiteral s) -> return $


### PR DESCRIPTION
Syntactic substitution in the evaluator relies on the fact that we have freshened every name, so variable capture cannot happen, and we don't have to do extra freshening as we go. However, internal names get generated in the debugger and they are not guaranteed to be freshen throughout the whole program! Bug #190 exposed this. Here I fixed it by appending the source line and column to the internal names being generated, providing freshening.

Also included in this fix is a bug surrounding the fact that we renamed the `Maybe` module but not the internal behaviour of `stringUncons`. Some debugging routines are left here for future use if helpful (but commented out).