### PR TITLE
grenchmark: load `benchmarkList` thru Cabal `data-files`; start on image config

### DIFF
--- a/TODO-nix-docker.md
+++ b/TODO-nix-docker.md
@@ -1,0 +1,9 @@
+# Nix & Docker
+## Status
+### 2024-01-02 raehik
+Most of the way there. `benchmarkList` is sorted in Cabal+Nix. Now we need a
+better way to access the benchmarks themselves.
+
+## Nice to-dos
+* remove GHC docs (build option somewhere)
+  * might force rebuilding too much...? check how much space it saves

--- a/benchmark/granule-benchmark.cabal
+++ b/benchmark/granule-benchmark.cabal
@@ -15,6 +15,9 @@ copyright:      2018-2023 authors
 license:        BSD3
 build-type:     Simple
 
+data-files:
+    benchmarkList
+
 source-repository head
   type: git
   location: https://github.com/granule-project/granule

--- a/benchmark/src/Language/Granule/Benchmarks.hs
+++ b/benchmark/src/Language/Granule/Benchmarks.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Language.Granule.Benchmarks where
 
-import Data.Csv 
+import Data.Csv
 
 import GHC.Generics
 import System.IO
@@ -12,6 +12,8 @@ import Data.Vector (toList)
 
 import Data.Char (isSpace)
 
+import Paths_granule_benchmark ( getDataDir )
+
 trim :: String -> String
 trim = f . f
    where f = reverse . dropWhile isSpace
@@ -19,20 +21,21 @@ trim = f . f
 rootDir :: String
 rootDir = "frontend/tests/cases/synthesis/"
 
-
-benchmarkFile :: FilePath
-benchmarkFile = "benchmark/benchmarkList"
+getBenchmarkFile :: IO FilePath
+getBenchmarkFile = do
+    dataDir <- getDataDir
+    pure $ dataDir<>"/benchmarkList"
 
 benchmarkList :: IO [(String, String, String, Bool)]
-benchmarkList = do 
-
-    csv <- LB.readFile benchmarkFile 
+benchmarkList = do
+    benchmarkFile <- getBenchmarkFile
+    csv <- LB.readFile benchmarkFile
     case decode NoHeader csv of
         (Left _) -> error "Couldn't parse benchmark list - bad data"
-        (Right res) -> do 
+        (Right res) -> do
             let resList = map (\(a, b, c, d) -> (trim a, trim b, trim c, read d)) $ toList res 
             return resList
-    
+
 
 benchmarkListFullPath :: [(String, String, String, Bool)] -> [(String, String, String, Bool)]
 benchmarkListFullPath = map (\(title, cat, path, incl) -> (title, cat, rootDir <> path, incl))

--- a/flake.nix
+++ b/flake.nix
@@ -107,6 +107,16 @@
           maxLayers = 100; # less than Docker max layers to allow extending
         };
 
+        packages.image-jackh = pkgs.dockerTools.streamLayeredImage {
+          name = "grenchmark-jackh";
+          tag = self.rev or "dev";
+          contents = [ pkgs.bash pkgs.coreutils pkgs.texlive.combined.scheme-basic ];
+          config = {
+            Entrypoint = [ "${self'.packages.granule-benchmark-gr-fixup}/bin/grenchmark" ];
+          };
+          maxLayers = 100;
+        };
+
       };
     };
 }


### PR DESCRIPTION
Targeting [synthesis-artefact](https://github.com/granule-project/granule/tree/synthesis-artefact).