### PR TITLE
grenchmark: fix package.yaml

### DIFF
--- a/benchmark/granule-benchmark.cabal
+++ b/benchmark/granule-benchmark.cabal
@@ -14,7 +14,6 @@ maintainer:     Dominic Orchard, Vilem-Benjamin Liepelt, Harley Eades III, Jack 
 copyright:      2018-2023 authors
 license:        BSD3
 build-type:     Simple
-
 data-files:
     benchmarkList
 

--- a/benchmark/package.yaml
+++ b/benchmark/package.yaml
@@ -11,6 +11,9 @@ dependencies:
 ghc-options:
 - -O2
 
+data-files:
+- benchmarkList
+
 executables:
   grenchmark:
     main: Language/Granule/Main.hs


### PR DESCRIPTION
Added `data-files` clause to generated Cabal file instead of `package.yaml`.