### PR TITLE
Fix typo in examples/further-examples.gr.md

### DIFF
--- a/examples/further-examples.gr.md
+++ b/examples/further-examples.gr.md
@@ -76,7 +76,7 @@ rest of the stack `xs` we use it once. An alternate definition of
 non-linearity on the elements:
 
 ~~~ granule
-peek' : forall m : Ext Nat, a, n . Vec (n+1) (a [m..m+1]) -> (a, Vec (n+1) (a [m..m]))
+peek' : forall {m : Ext Nat, a, n} . Vec (n+1) (a [m..m+1]) -> (a, Vec (n+1) (a [m..m]))
 peek' (Cons [x] xs) = (x, Cons [x] xs)
 ~~~
 


### PR DESCRIPTION
Fix typo in [examples/further-examples.gr.md](https://github.com/granule-project/granule/blob/8d39141a6c57d8d46405792940d86f9eca3bb171/examples/further-examples.gr.md).
The type annotation for `peek'` is missing `{}` for type variables.

