### PR TITLE
Fix example/test

### DIFF
--- a/examples/intro.gr.md
+++ b/examples/intro.gr.md
@@ -555,7 +555,7 @@ leak = hash secret
 (`gr examples/intro.gr.md --literate-env-name grill7`)
 
 ~~~ granule
-hash : forall {l : Level} . Int [l] -> Int [l]
+hash : forall {l : Sec} . Int [l] -> Int [l]
 hash [x] = [x*x*x]
 ~~~
 


### PR DESCRIPTION
Fixes #247 by replacing`Level` (which is now gated by the `language SecurityLevels` extension) with `Sec` which is what we use now for privacy.