### PR TITLE
WIP: Adapt to GHC 9.6

### DIFF
--- a/compiler/app/Language/Granule/Compiler.hs
+++ b/compiler/app/Language/Granule/Compiler.hs
@@ -17,7 +17,7 @@ import System.Directory (getAppUserDataDirectory, getCurrentDirectory)
 import System.FilePath (takeFileName)
 import "Glob" System.FilePath.Glob (glob)
 import Options.Applicative
-import Options.Applicative.Help.Pretty (string)
+import qualified Options.Applicative.Help.Pretty as P
 
 import Language.Granule.Checker.Checker
 import Language.Granule.Syntax.Def (extendASTWith)
@@ -177,7 +177,7 @@ getGrCommandLineArgs = customExecParser (prefs disambiguate) parseGrConfig
 
 parseGrConfig :: ParserInfo ([FilePath], GrConfig)
 parseGrConfig = info (go <**> helper) $ briefDesc
-    <> (headerDoc . Just . string . unlines)
+    <> (headerDoc . Just . P.pretty . unlines)
             [ "The Granule Compiler"
             , "version: "     <> showVersion version
             , "branch: "      <> $(gitBranch)

--- a/frontend/granule-frontend.cabal
+++ b/frontend/granule-frontend.cabal
@@ -112,7 +112,7 @@ library
     , monad-memo
     , mtl >=2.2.1
     , raw-strings-qq
-    , sbv >=8.5 && <10
+    , sbv >=8.5
     , split
     , syb >=0.6
     , syz >=0.2.0.0

--- a/frontend/package.yaml
+++ b/frontend/package.yaml
@@ -92,7 +92,7 @@ library:
   - containers
   - control-monad-omega
   - mtl >=2.2.1
-  - sbv >=8.5 && < 10
+  - sbv >=8.5
   - transformers >=0.5
   - text
   - time

--- a/frontend/src/Language/Granule/Checker/Checker.hs
+++ b/frontend/src/Language/Granule/Checker/Checker.hs
@@ -17,6 +17,7 @@
 module Language.Granule.Checker.Checker where
 
 import Control.Arrow (second)
+import Control.Monad
 import Control.Monad.State.Strict
 import Control.Monad.Except (throwError)
 import Data.List.NonEmpty (NonEmpty(..))

--- a/frontend/src/Language/Granule/Checker/Constraints.hs
+++ b/frontend/src/Language/Granule/Checker/Constraints.hs
@@ -11,7 +11,7 @@
 module Language.Granule.Checker.Constraints where
 
 --import Data.Foldable (foldrM)
-import Data.SBV hiding (kindOf, name, symbolic, isSet)
+import Data.SBV hiding (kindOf, name, symbolic, isSet, Exists)
 import qualified Data.SBV.Set as S
 import Data.Maybe (mapMaybe)
 import Control.Monad (liftM2)
@@ -302,24 +302,24 @@ class QuantifiableScoped a where
   existentialScoped :: String -> (SBV a -> Symbolic SBool) -> Symbolic SBool
 
 instance QuantifiableScoped Integer where
-  universalScoped v = universal [v]
-  existentialScoped v = existential [v]
+  universalScoped v = undefined --universal [v]
+  existentialScoped v = undefined -- existential [v]
 
 instance QuantifiableScoped Rational where
-  universalScoped v = universal [v]
-  existentialScoped v = existential [v]
+  universalScoped v = undefined -- universal [v]
+  existentialScoped v = undefined -- existential [v]
 
 instance QuantifiableScoped Bool where
-  universalScoped v = universal [v]
-  existentialScoped v = existential [v]
+  universalScoped v = undefined -- universal [v]
+  existentialScoped v = undefined -- existential [v]
 
 instance QuantifiableScoped Float where
-  universalScoped v = universal [v]
-  existentialScoped v = existential [v]
+  universalScoped v = undefined -- universal [v]
+  existentialScoped v = undefined -- existential [v]
 
 instance QuantifiableScoped (RCSet SSetElem) where
-  universalScoped v = universal [v]
-  existentialScoped v = existential [v]
+  universalScoped v = undefined -- universal [v]
+  existentialScoped v = undefined -- existential [v]
 
 
 -- Compile a constraint into a symbolic bool (SBV predicate)

--- a/frontend/src/Language/Granule/Checker/Constraints/SFrac.hs
+++ b/frontend/src/Language/Granule/Checker/Constraints/SFrac.hs
@@ -54,12 +54,12 @@ freeSFrac nm = do
 
 existsSFrac :: String -> Symbolic SFrac
 existsSFrac nm = do
-  v <- sbvExists $ nm <> "_fVal"
-  constrain $ fractionConstraint v
+  v <- free $ nm <> "_fVal"
+  constrain $ \(Exists v) -> fractionConstraint v
   return $ SFrac v
 
 forallSFrac :: String -> Symbolic SFrac
 forallSFrac nm = do
-  v <- sbvForall $ nm <> "_fVal"
-  constrain $ fractionConstraint v
+  v <- free $ nm <> "_fVal"
+  constrain $ \(Forall v) -> fractionConstraint v
   return $ SFrac v

--- a/frontend/src/Language/Granule/Checker/Constraints/SNatX.hs
+++ b/frontend/src/Language/Granule/Checker/Constraints/SNatX.hs
@@ -59,14 +59,14 @@ freeSNatX nm = do
 
 existsSNatX :: String -> Symbolic SNatX
 existsSNatX nm = do
-  v <- sbvExists $ nm <> "_xVal"
-  constrain $ representationConstraint v
+  v <- free $ nm <> "_xVal"
+  constrain $ \(Exists v) -> representationConstraint v
   return $ SNatX v
 
 forallSNatX :: String -> Symbolic SNatX
 forallSNatX nm = do
-  v <- sbvForall $ nm <> "_xVal"
-  constrain $ representationConstraint v
+  v <- free $ nm <> "_xVal"
+  constrain $ \(Forall v) -> representationConstraint v
   return $ SNatX v
 
 -- main :: IO ()

--- a/frontend/src/Language/Granule/Checker/Patterns.hs
+++ b/frontend/src/Language/Granule/Checker/Patterns.hs
@@ -8,6 +8,7 @@
 -- | Type checking patterns
 module Language.Granule.Checker.Patterns where
 
+import Control.Monad
 import Control.Monad.Except (throwError)
 import Control.Monad.State.Strict
 import Data.List.NonEmpty (NonEmpty(..))

--- a/frontend/src/Language/Granule/Checker/Types.hs
+++ b/frontend/src/Language/Granule/Checker/Types.hs
@@ -10,6 +10,7 @@
 module Language.Granule.Checker.Types where
 
 import Control.Monad.State.Strict
+import Control.Monad
 import Data.List (sortBy, sort)
 
 import Language.Granule.Checker.Coeffects

--- a/frontend/src/Language/Granule/Syntax/Expr.hs
+++ b/frontend/src/Language/Granule/Syntax/Expr.hs
@@ -66,7 +66,7 @@ data ValueF ev a value expr =
      -- /\(x : k) . t
     -- Extensible part
     | ExtF a ev
-   deriving (Generic, Eq, Rp.Data)
+   deriving (Generic, Eq, Rp.Data, Functor)
 
 deriving instance (Show ev, Show a, Show value, Show expr)
     => Show (ValueF ev a value expr)
@@ -152,7 +152,7 @@ data ExprF ev a expr value =
   | UnpackF Span a Bool Id Id expr expr
      -- unpack <a, x> = e1 in e2
   | HoleF Span a Bool [Id] (Maybe Hints)
-  deriving (Generic, Eq, Rp.Data)
+  deriving (Generic, Eq, Rp.Data, Functor)
 
 data Operator
   = OpLesser

--- a/frontend/src/Language/Granule/Synthesis/Monad.hs
+++ b/frontend/src/Language/Granule/Synthesis/Monad.hs
@@ -11,6 +11,7 @@ import Language.Granule.Checker.Monad
 import qualified Data.Generics.Zipper as Z
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.List (isInfixOf)
+import Control.Monad
 import Control.Monad.Except
 import Control.Monad.State.Strict
 import Control.Monad.Logic

--- a/frontend/src/Language/Granule/Synthesis/Synth.hs
+++ b/frontend/src/Language/Granule/Synthesis/Synth.hs
@@ -43,6 +43,7 @@ import Language.Granule.Synthesis.Common
 
 
 import Data.Either (lefts, rights, fromRight)
+import Control.Monad
 import Control.Monad.State.Strict
 
 -- import qualified Control.Monad.State.Strict as State (get)

--- a/frontend/src/Language/Granule/Synthesis/SynthLinearBase.hs
+++ b/frontend/src/Language/Granule/Synthesis/SynthLinearBase.hs
@@ -23,6 +23,7 @@ import Language.Granule.Synthesis.Contexts
 import Language.Granule.Synthesis.Common
 import Language.Granule.Utils
 
+import Control.Monad
 import Control.Monad.State.Strict
 import qualified System.Clock as Clock
 import Data.List (sortBy)

--- a/frontend/tests/hspec/Data/Bifunctor/FoldableSpec.hs
+++ b/frontend/tests/hspec/Data/Bifunctor/FoldableSpec.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DeriveFunctor #-}
 
 {-# options_ghc -Wno-missing-pattern-synonym-signatures #-}
 
@@ -15,6 +16,7 @@ data ExprF expr val =
     | OrF expr expr
     | NotF expr
     | ValF val
+    deriving Functor
 $(deriveBifunctor ''ExprF)
 
 type Expr = Fix2 ExprF ValueF
@@ -35,6 +37,7 @@ data ValueF val expr =
     LitF Bool
     | IgnoreF expr Bool -- `expr` does nothing, it's just here to
                         -- demonstrate mutual recursion.
+    deriving Functor
 $(deriveBifunctor ''ValueF)
 
 type Value = Fix2 ValueF ExprF

--- a/interpreter/src/Language/Granule/Interpreter.hs
+++ b/interpreter/src/Language/Granule/Interpreter.hs
@@ -38,7 +38,7 @@ import System.FilePath (takeFileName)
 import qualified System.Timeout
 import "Glob" System.FilePath.Glob (glob)
 import Options.Applicative
-import Options.Applicative.Help.Pretty (string)
+import qualified Options.Applicative.Help.Pretty as P
 import Control.Monad.State.Strict
 
 import Language.Granule.Context
@@ -414,7 +414,7 @@ getGrCommandLineArgs = customExecParser (prefs disambiguate) parseGrConfig
 
 parseGrConfig :: ParserInfo ([FilePath], GrConfig)
 parseGrConfig = info (go <**> helper) $ briefDesc
-    <> (headerDoc . Just . string . unlines)
+    <> (headerDoc . Just . P.pretty . unlines)
             [ "The Granule Interpreter"
             , "version: "     <> showVersion version
             , "branch: "      <> $(gitBranch)

--- a/repl/app/Language/Granule/Main.hs
+++ b/repl/app/Language/Granule/Main.hs
@@ -19,6 +19,7 @@ import qualified Data.Map as M
 import qualified Data.List.NonEmpty as NonEmpty (NonEmpty, filter, fromList)
 import qualified Language.Granule.Checker.Monad as Checker
 import Control.Exception (try)
+import Control.Monad
 import Control.Monad.State
 import Control.Monad.Trans.Reader
 import qualified Control.Monad.Except as Ex
@@ -146,7 +147,7 @@ helpMenu = unlines
       ]
 
 handleCMD :: (?globals::Globals) => String -> REPLStateIO ()
-handleCMD "" = Ex.return ()
+handleCMD "" = return ()
 handleCMD s =
    case parseLine s of
     Right l -> handleLine l

--- a/server/app/Language/Granule/Server.hs
+++ b/server/app/Language/Granule/Server.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE TypeOperators #-}
 
@@ -16,6 +17,7 @@ import Control.Monad.Reader (ReaderT, ask, runReaderT)
 import Control.Monad.Trans.Class
 import Data.Default (Default(..))
 import Data.Foldable (toList)
+import Data.Kind (Type)
 import Data.List (isInfixOf,isPrefixOf)
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.Split
@@ -57,6 +59,7 @@ instance Default LsState where
 newLsStateVar :: IO (MVar LsState)
 newLsStateVar = newMVar def
 
+type LspS :: Type -> Type
 type LspS = LspT () (ReaderT (MVar LsState) IO)
 
 getLsState :: LspS LsState
@@ -339,12 +342,10 @@ main = do
             Just
               ( TextDocumentSyncOptions
                 (Just True)
-                (Just syncKind)
+                (Just TextDocumentSyncKind_Full)
                 (Just False)
                 (Just False)
                 (Just $ InR $ SaveOptions $ Just True)
               )
         }
     }
-  where
-    syncKind = TextDocumentSyncKind_Full

--- a/server/granule-language-server.cabal
+++ b/server/granule-language-server.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-21.25
+resolver: lts-22.44
 packages:
 - frontend/
 - interpreter/
@@ -10,8 +10,10 @@ packages:
 
 # Dependency packages to be pulled from upstream that are not in the resolver
 extra-deps:
-- text-replace-0.1.0.3
-- sbv-9.2
+- git: https://github.com/mixphix/text-replace.git
+  commit: 301b45914229f40d715268a825b38524bc05e5d8
+  subdirs:
+  - text-replace
 - syz-0.2.0.0
 - lsp-types-2.3.0.1
 - lsp-2.7.0.1


### PR DESCRIPTION
It would be very nice to get the code to compile with GHC 9.6 at least, since the latest version of the Haskell language server doesn't work for earlier versions.

While trying to get this to work I discovered two bigger sites:
- The `lsp` and `lsp-types` libraries had significant changes due to the fact that they generate their types automatically from the LSP metamodel.
- There was a major change in how `sbv` treats universally and existentially quantified variables. See release notes to version 10.1 here: https://github.com/LeventErkok/sbv/blob/master/CHANGES.md Unfortunately, this version of `sbv` is the same one that introduced compatibility with GHC 9.6 :crying_cat_face: 

This PR is quite messy and the logic for universals and existentials is probably not correct yet. But it gives a rough idea about what needs to be changed.