### PR TITLE
Use new version of SBV

### DIFF
--- a/frontend/granule-frontend.cabal
+++ b/frontend/granule-frontend.cabal
@@ -112,7 +112,7 @@ library
     , monad-memo
     , mtl >=2.2.1
     , raw-strings-qq
-    , sbv >=8.5 && <10
+    , sbv
     , split
     , syb >=0.6
     , syz >=0.2.0.0

--- a/frontend/package.yaml
+++ b/frontend/package.yaml
@@ -92,7 +92,7 @@ library:
   - containers
   - control-monad-omega
   - mtl >=2.2.1
-  - sbv >=8.5 && < 10
+  - sbv
   - transformers >=0.5
   - text
   - time

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,7 +11,6 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 extra-deps:
 - text-replace-0.1.0.3
-- sbv-9.2
 - syz-0.2.0.0
 - lsp-types-2.3.0.1
 - lsp-2.7.0.1


### PR DESCRIPTION
This is the current version of the patch. The core change happens in `compileQuantScoped`

```diff
-compileQuantScoped :: SymVal a => Quantifier -> String -> (SBV a -> Symbolic SBool) -> Symbolic SBool
-compileQuantScoped ForallQ  s = universal [s]
-compileQuantScoped BoundQ   s = universal [s]
-compileQuantScoped _ s = existential [s]
+compileQuantScoped :: SymVal a => Quantifier -> String -> (SBV a -> SBool) -> SBool
+compileQuantScoped ForallQ   _s k = quantifiedBool $ \(Data.SBV.Forall x) -> k x
+compileQuantScoped BoundQ    _s k = quantifiedBool $ \(Data.SBV.Forall x) -> k x
+compileQuantScoped InstanceQ _s k = quantifiedBool $ \(Data.SBV.Exists x) -> k x

```
which requires changing all monadic code which produces `Symbolic SBool` to non-monadic code which produces just `SBool`.

Unfortunately, this generates SMT problems for Z3 that currently timeout in a lot of cases. This needs some further investigation...