### PR TITLE
Fix all hlint warnings in interpreter/

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -51,6 +51,9 @@
 # - ignore: {name: Use let}
 # - ignore: {name: Use const, within: SpecialModule} # Only within certain modules
 - ignore: {name: Redundant do}
+- ignore: {name: Avoid lambda}
+- ignore: {name: Use tuple-section}
+- ignore: {name: Redundant lambda}
 
 # Define some custom infix operators
 # - fixity: infixr 3 ~^#^~

--- a/interpreter/tests/Golden.hs
+++ b/interpreter/tests/Golden.hs
@@ -3,16 +3,15 @@ import Control.Monad (unless)
 import Data.Algorithm.Diff (getGroupedDiff)
 import Data.Algorithm.DiffOutput (ppDiff)
 import Data.List (sort, isInfixOf)
+import Data.Functor((<&>))
 import Test.Tasty (defaultMain, TestTree, testGroup)
 import Test.Tasty.Golden (goldenVsFile)
 import qualified Test.Tasty.Golden as G
 import Test.Tasty.Golden.Advanced (goldenTest)
-import System.Directory (renameFile)
+import System.Directory (renameFile, doesFileExist)
 import System.Exit (ExitCode)
 import System.FilePath (dropExtension, pathSeparator)
 import qualified System.IO.Strict as Strict (readFile)
---import System.Environment
-import System.Directory (doesFileExist)
 
 import Language.Granule.Interpreter (InterpreterResult(..), InterpreterError(..))
 import qualified Language.Granule.Interpreter as Interpreter
@@ -74,7 +73,7 @@ applyConfig cfgs files = aux cfgs []
 
 
 findByExtension :: Config -> [FilePath] -> FilePath -> IO [FilePath]
-findByExtension config exs path = G.findByExtension exs path >>= (return . sort . applyConfig config)
+findByExtension config exs path = G.findByExtension exs path <&> (sort . applyConfig config)
 
 goldenTestsNegative :: Config -> IO TestTree
 goldenTestsNegative config = do


### PR DESCRIPTION
Fixes (or explicitly ignores) all hlint warnings in the `interpreter/*` subdirectory. We go from 777 warnings in total to 683 after this PR.

All the changes are extremely local and suggested by hlint.