### PR TITLE
Set coeffect issues

### DIFF
--- a/frontend/src/Language/Granule/Checker/Kinding.hs
+++ b/frontend/src/Language/Granule/Checker/Kinding.hs
@@ -1303,7 +1303,12 @@ requiresSolver s ty = do
   case result of
     -- Checking as coeffect or effect caused an error so ignore
     Left _  -> return False
-    Right _ -> putChecker >> return True
+    Right _ ->
+      -- avoid putting sets into the solver as the solver is weak on this
+      case isSet ty of
+       Just _ ->  putChecker >> return False
+       Nothing ->
+        putChecker >> return True
 
 instance Unifiable Substitutors where
     unify' (SubstT t) (SubstT t') = unify' t t'

--- a/frontend/tests/cases/negative/simple/set.gr.output
+++ b/frontend/tests/cases/negative/simple/set.gr.output
@@ -1,0 +1,3 @@
+Type checking failed: 
+Falsifiable theorem: frontend/tests/cases/negative/simple/set.gr:14:1:
+  When checking `non-example`, {Contacts} is not approximatable by {Location} for type Set Privilege


### PR DESCRIPTION
Previously there was a hack in `Kinding.hs` to filter out constraints which the solver wasn't good at solving. Here I'm adding this back in for testing purposes. It's not intended to be merged back in.

It does "fix" some failing tests like [examples/effects_nondet.gr](examples/effects_nondet.gr) and [examples/effects_state.gr](examples/effects_state.gr), however it causes other test failures.