### PR TITLE
Make sublibraries public

### DIFF
--- a/granule.cabal
+++ b/granule.cabal
@@ -68,6 +68,10 @@ common granule-ghc-warnings
 --
 --
 
+
+-- Dummy toplevel library component that is needed for external projects that depend on internal sublibraries.
+library
+
 library frontend
   import: granule-default-lang
   import: granule-dependencies


### PR DESCRIPTION
@jacobpake uses the frontend library from within the granule llvm compiler. We therefore need to make the sublibraries usable from within other projects.